### PR TITLE
Support multi-extension FITS ingest and specutils fallback

### DIFF
--- a/PATCH_NOTES/PATCH_NOTES_v0.1.0(c).md
+++ b/PATCH_NOTES/PATCH_NOTES_v0.1.0(c).md
@@ -1,0 +1,33 @@
+# Spectra App v0.1.0 (c) — FITS multi-extension support
+
+## Highlights
+- Extended FITS ingest to read spectra with separate wavelength extensions and inverse-variance
+  uncertainties while preserving provenance.
+- Added a specutils-powered fallback for non-linear or tabular wavelength solutions so SDSS-style
+  products ingest without manual WCS decoding.
+- Updated regression coverage, documentation, and version metadata for v0.1.0c.
+
+## Changes
+- Enhanced `server/ingest/fits_loader.py` with companion HDU discovery, `ivar` → σ conversion,
+  and a specutils fallback pipeline that captures provenance when non-linear WCS handling is
+  delegated externally.
+- Added regression tests for multi-extension FITS payloads and specutils-driven ingestion in
+  `tests/test_fits_loader.py`.
+- Documented the new capabilities in `atlas/ingest_fits.md` and bumped package/config versions to
+  `0.1.0c`.
+
+## Known Issues
+- Archive fetchers (MAST/SDSS) remain stubbed; Star Hub lists resolver results only.
+- Replay script still limited to canonical spectra reconstruction; UI rebuild CLI pending.
+- Performance optimisations (async ingest, LOD) are outstanding.
+
+## Verification
+- `ruff check . --fix`
+- `black .`
+- `mypy .`
+- `pytest`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-UI-Contract.py`

--- a/app/config/version.json
+++ b/app/config/version.json
@@ -1,4 +1,4 @@
 {
-  "app_version": "0.1.0b",
+  "app_version": "0.1.0c",
   "schema_version": 2
 }

--- a/atlas/ingest_fits.md
+++ b/atlas/ingest_fits.md
@@ -5,7 +5,10 @@
   normalises them into a shared ingest result. The loader is resilient to:
   - Tables with `WAVELENGTH`/`FLUX` columns (including `loglam` grids that are exponentiated).
   - Image HDUs with linear WCS dispersion (`CRVAL1`, `CDELT1`, `CRPIX1`, `CTYPE1`, `CUNIT1`).
-  - Companion uncertainty data stored as error columns or dedicated `ERR`-style HDUs.
+  - Multi-extension products where flux and wavelength live in separate HDUs (e.g. SDSS
+    `LOG_LAM` companions) as well as inverse-variance error columns or `ERR`-style HDUs.
+  - Non-linear or tabular wavelength solutions by delegating to `specutils.Spectrum`/`Spectrum1D`
+    loaders when native parsing cannot recover a dispersion axis.
 - Provenance captures the selected HDU, wavelength/flux units, air/vacuum hints, a SHA-256 hash,
   and WCS keywords used to build the grid.
 - Metadata harvested from headers populates `TraceMetadata` (target, instrument, telescope, RA/Dec,

--- a/brains/v0.1.0c__assistant__fits_wcs.md
+++ b/brains/v0.1.0c__assistant__fits_wcs.md
@@ -1,0 +1,45 @@
+# v0.1.0c — FITS multi-extension ingestion
+
+## Context
+- Goal: extend the FITS ingest path to handle SDSS-style multi-extension tables and non-linear/tabular
+  wavelength solutions while keeping provenance intact.
+- Starting point: v0.1.0b supported single-HDU FITS spectra with linear WCS and basic uncertainty
+  harvesting.
+
+## Changes
+- Updated `server/ingest/fits_loader.py` to discover companion wavelength HDUs, translate `ivar`
+  columns into σ arrays, and fall back to `specutils` loaders when the dispersion axis cannot be
+  derived from local headers.
+- Logged provenance for the new branches (companion HDUs vs. specutils) and hardened uncertainty
+  detection to inspect the active HDU before scanning siblings.
+- Added regression tests for multi-extension FITS files and specutils-backed ingestion plus atlas
+  updates describing the new coverage.
+
+## Decisions
+- Prefer keeping the native parsing path first to avoid the overhead of specutils unless necessary,
+  but capture in provenance when the fallback is used so replay tooling can mirror the decision.
+- Treat inverse-variance arrays as first-class uncertainties, converting to σ to align with existing
+  propagation rules.
+
+## Tests & Evidence
+- `python -m pytest tests/test_fits_loader.py`
+- `python -m pytest tests`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+
+## Regressions Prevented
+- Regression coverage for SDSS-style FITS ensures future refactors retain support for companion
+  wavelength tables and inverse-variance arrays.
+- Specutils fallback test prevents silent failures when ingesting non-linear WCS products that lack
+  conventional FITS keywords.
+
+## Follow-ups
+- Implement archive fetchers (MAST/SDSS) to exercise the ingest path with live catalog products.
+- Extend replay tooling to recognise specutils-derived provenance for deterministic rebuilds.
+- Investigate caching of specutils loaders to amortise cost when ingesting many spectra in a session.
+
+## Checklist
+- [x] Atlas updated
+- [ ] Docs updated
+- [x] Tests updated

--- a/handoffs/HANDOFF_v0.1.0(c).md
+++ b/handoffs/HANDOFF_v0.1.0(c).md
@@ -1,0 +1,47 @@
+# HANDOFF 0.1.0c — FITS multi-extension ingestion
+## 1) Summary of This Run
+- Extended FITS ingest to support spectra with companion wavelength extensions and inverse-variance
+  uncertainties, converting them into the canonical model with provenance preserved.
+- Added a specutils-based fallback path for non-linear/tabular WCS solutions and captured which path
+  produced the dispersion axis so replay tooling can mirror the decision.
+- Updated regression tests, atlas documentation, and version metadata for v0.1.0c.
+
+## 2) Current State of the Project
+- **Working tabs:** Overlay (ASCII+FITS with multi-extension + specutils fallback), Differential,
+  Star Hub (SIMBAD resolver with fixtures), Docs.
+- **Known gaps:** Archive fetchers (MAST/SDSS) remain stubbed; replay CLI/UI reconstruction still
+  pending; docs tab still a high-level placeholder.
+- **Performance:** Adequate for sample traces; specutils fallback adds overhead for complex FITS but
+  runs only when native parsing fails.
+- **Debt:** Archive adapters, replay automation, richer docs/accessibility review, and ingest
+  performance profiling/caching.
+
+## 3) Next Steps (Prioritized)
+1) Implement `server/fetchers/mast.py` and `server/fetchers/sdss.py` with fixture-backed tests that
+   exercise metadata/provenance paths.
+2) Build the export replay CLI/UI reconstruction tooling to honour provenance (including specutils
+   fallback indicators).
+3) Profile specutils fallback performance and investigate caching or format hints for bulk ingest
+   workloads.
+
+## 4) Decisions & Rationale
+- Prioritised native FITS parsing and only invoked specutils when dispersion information is missing to
+  keep the common path lightweight while still supporting complex archives.
+- Normalised inverse-variance (`ivar`) arrays into σ to align with existing numerical safeguards and
+  uncertainty propagation rules.
+- Recorded provenance for both companion HDU resolution and specutils fallback so manifest replay can
+  reconstruct the ingest flow deterministically.
+
+## 5) References
+- Atlas: `atlas/ingest_fits.md`
+- Brains: `brains/v0.1.0c__assistant__fits_wcs.md`
+- Patch notes: `PATCH_NOTES/PATCH_NOTES_v0.1.0(c).md`
+- Tests: `tests/test_fits_loader.py`
+
+## 6) Quick Start for the Next AI
+- Install: `pip install -e .[dev]`
+- Run app: `streamlit run app/app_patched.py`
+- Quality gates: `ruff check . --fix`, `black .`, `mypy .`, `python -m pytest`, then
+  `python tools/verifiers/Verify-*.py`
+- Sample data: ASCII (`data/examples/example_spectrum.csv`), single-HDU FITS (`data/examples/example_spectrum.fits`),
+  plus tests generate SDSS-like fixtures on demand.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectra-app"
-version = "0.1.0b0"
+version = "0.1.0c0"
 description = "Research-grade spectral comparison toolkit"
 readme = "README.md"
 authors = [{name = "Spectra App Team"}]

--- a/tests/test_fits_loader.py
+++ b/tests/test_fits_loader.py
@@ -45,3 +45,82 @@ def test_canonicalize_fits_converts_air_wavelengths(tmp_path: Path) -> None:
     assert canonical.metadata.wavelength_standard == "vacuum"
     assert canonical.wavelength_vac_nm[0] > 600.0
     assert "air_to_vacuum" in {event.step for event in canonical.provenance}
+
+
+def test_load_fits_spectrum_supports_companion_wavelength_table(tmp_path: Path) -> None:
+    wavelengths = np.array([4100.0, 4200.0, 4300.0, 4400.0], dtype=float)
+    flux = np.array([1.2, 0.9, 1.8, 1.1], dtype=float)
+    inverse_variance = np.array([25.0, 16.0, 9.0, 4.0], dtype=float)
+
+    flux_hdu = fits.BinTableHDU.from_columns(
+        [
+            fits.Column(
+                name="FLUX",
+                format="D",
+                array=flux,
+                unit="erg / (Angstrom cm2 s)",
+            ),
+            fits.Column(name="IVAR", format="D", array=inverse_variance),
+        ],
+        name="SPECTRUM",
+    )
+    flux_hdu.header["OBJECT"] = "SDSS Target"
+    flux_hdu.header["INSTRUME"] = "BOSS"
+    flux_hdu.header["AIRORVAC"] = "vac"
+
+    wave_hdu = fits.BinTableHDU.from_columns(
+        [fits.Column(name="LOGLAM", format="D", array=np.log10(wavelengths))],
+        name="WAVE",
+    )
+
+    path = tmp_path / "sdss_like.fits"
+    fits.HDUList([fits.PrimaryHDU(), flux_hdu, wave_hdu]).writeto(path)
+
+    result = load_fits_spectrum(path)
+
+    assert result.metadata.instrument == "BOSS"
+    assert result.wavelength_unit.lower() == "angstrom"
+    assert np.allclose(result.wavelength, wavelengths)
+
+    expected_sigma = np.full(inverse_variance.shape, np.nan, dtype=float)
+    mask = inverse_variance > 0
+    expected_sigma[mask] = 1.0 / np.sqrt(inverse_variance[mask])
+    assert result.uncertainties is not None
+    assert np.allclose(result.uncertainties, expected_sigma, equal_nan=True)
+
+    provenance = result.provenance[0].parameters["wcs"]
+    assert provenance["source"] == "companion_column"
+    assert provenance["column"].lower() == "loglam"
+
+
+def test_load_fits_spectrum_uses_specutils_fallback(tmp_path: Path) -> None:
+    wavelengths = np.array([5100.0, 5125.0, 5155.0], dtype=float)
+    flux = np.array([0.5, 0.7, 0.6], dtype=float)
+    sigma = np.array([0.05, 0.07, 0.06], dtype=float)
+
+    table_hdu = fits.BinTableHDU.from_columns(
+        [
+            fits.Column(name="FLUX", format="D", array=flux, unit="erg / (Angstrom cm2 s)"),
+            fits.Column(name="AXIS", format="D", array=wavelengths, unit="Angstrom"),
+            fits.Column(name="SIGMA", format="D", array=sigma, unit="erg / (Angstrom cm2 s)"),
+        ],
+        name="DATA",
+    )
+    table_hdu.header["OBJECT"] = "Specutils Source"
+    table_hdu.header["INSTRUME"] = "FallbackSpec"
+    table_hdu.header["AIRORVAC"] = "vac"
+
+    path = tmp_path / "specutils_table.fits"
+    fits.HDUList([fits.PrimaryHDU(), table_hdu]).writeto(path)
+
+    result = load_fits_spectrum(path)
+
+    assert result.metadata.instrument == "FallbackSpec"
+    assert np.allclose(result.wavelength, wavelengths)
+    assert result.wavelength_unit.lower() == "angstrom"
+    assert result.uncertainties is not None
+    assert np.allclose(result.uncertainties, sigma)
+
+    provenance = result.provenance[0].parameters["wcs"]
+    assert provenance["source"] == "specutils"
+    assert provenance["format"] in {"auto", "tabular-fits"}


### PR DESCRIPTION
## Summary
- extend the FITS loader to detect companion wavelength HDUs, translate inverse variance columns, and fall back to specutils for non-linear/tabular WCS
- add regression coverage for multi-extension and specutils-driven FITS ingestion and update atlas/docs plus version metadata to v0.1.0c
- refresh continuity artefacts (patch notes, brains, handoff) for the new release letter

## Testing
- ruff check .
- black --check .
- mypy .
- python -m pytest tests -q
- python tools/verifiers/Verify-Atlas.py
- python tools/verifiers/Verify-Brains.py
- python tools/verifiers/Verify-PatchNotes.py
- python tools/verifiers/Verify-Handoff.py
- PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d3149c437c8329938cbb12fb881abc