### PR TITLE
Fix ASCII upload column detection with BOM headers

### DIFF
--- a/tests/test_ascii_loader.py
+++ b/tests/test_ascii_loader.py
@@ -17,6 +17,15 @@ def test_ascii_loader_parses_units(tmp_path: Path) -> None:
     assert canonical.metadata.flux_units == "arb"
 
 
+def test_ascii_loader_handles_bom_headers() -> None:
+    content = "\ufeffWavelength (nm),Flux (arb),Target\n510.0,1.2,Example Object\n".encode("utf-8")
+    result = load_ascii_spectrum(content, "bom.csv")
+    assert result.wavelength_unit == "nm"
+    assert result.metadata.target == "Example Object"
+    canonical = canonicalize_ascii(result)
+    assert canonical.metadata.target == "Example Object"
+
+
 def test_session_deduplication() -> None:
     fixture = Path("data/examples/example_spectrum.csv")
     result = load_ascii_spectrum(fixture.read_bytes(), fixture.name)


### PR DESCRIPTION
## Summary
- strip invisible BOM and zero-width characters from ASCII headers before alias detection
- normalise metadata column lookup so target/instrument inference survives messy casing
- add a regression test covering BOM-prefixed uploads

## Testing
- PYTHONPATH=. pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d31c3b9e688329b3719e5a895d663c