### PR TITLE
Handle headerless ASCII uploads and fix packaging version

### DIFF
--- a/PATCH_NOTES/PATCH_NOTES_v0.1.0(d).md
+++ b/PATCH_NOTES/PATCH_NOTES_v0.1.0(d).md
@@ -1,0 +1,34 @@
+# Spectra App v0.1.0 (d) — Resilient ASCII uploads
+
+## Highlights
+- Normalised ASCII header tokens so uploads with mixed casing, camel case, or punctuation variants
+  still detect wavelength, flux, and metadata fields automatically.
+- Expanded metadata synonym detection (Target/Object/Instrument/Telescope/Observer) and filtered
+  null-like values to keep provenance clean while deriving display labels reliably.
+- Added regression coverage for messy header combinations and bumped version metadata to 0.1.0d.
+
+## Changes
+- Hardened `server/ingest/ascii_loader.py` with canonical header tokenisation, richer alias sets,
+  and smarter metadata extraction/label inference so "FluxDensity", "Wave Length", etc. parse
+  correctly.
+- Added regression test `tests/test_ascii_loader.py::test_ascii_loader_handles_messy_synonyms` to
+  lock in support for the broadened alias detection.
+- Documented the ingestion changes in `atlas/ingest_ascii.md` and updated version artifacts to
+  `0.1.0d`.
+
+## Known Issues
+- Archive fetchers (MAST/SDSS) remain stubbed; Star Hub continues to rely on fixtures.
+- Replay CLI/UI reconstruction tooling still pending, and docs tab needs expansion beyond the
+  current overview content.
+- Performance investigations for bulk ingest and async pipelines remain on the roadmap.
+
+## Verification
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`

--- a/PATCH_NOTES/PATCH_NOTES_v0.1.0(e).md
+++ b/PATCH_NOTES/PATCH_NOTES_v0.1.0(e).md
@@ -1,0 +1,28 @@
+# Spectra App v0.1.0 (e) — Headerless ASCII heuristics
+
+## Highlights
+- Recover headerless and sparsely-labelled ASCII uploads by sniffing numeric columns when alias-based
+  detection fails.
+- Drop rows with invalid wavelength/flux pairs and surface the retained counts alongside detection
+  strategy metadata in provenance for easier debugging.
+- Align packaging metadata with PEP 440 using `0.1.0.dev5` so editable installs succeed again.
+
+## Changes
+- Rerun pandas parsing without headers when the first row is numeric, rename inferred columns, and fall
+  back to monotonic/coverage heuristics to choose wavelength and flux arrays.
+- Guard unit reporting so guessed wavelength columns emit `unknown` instead of placeholder labels and log
+  the heuristic detection method, headerless flag, and row counts in provenance events.
+- Expand regression coverage with a headerless CSV fixture to assert numeric inference, provenance
+  annotations, and unit fallbacks.
+- Updated ASCII ingest atlas documentation to describe the headerless retry, numeric heuristics, row
+  filtering, and enriched provenance fields.
+- Bump `pyproject.toml` to `0.1.0.dev5` and the app version badge to `0.1.0e` to unlock pip installs and
+  satisfy release artifact verifiers.
+
+## Verification
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`

--- a/app/config/version.json
+++ b/app/config/version.json
@@ -1,4 +1,4 @@
 {
-  "app_version": "0.1.0c",
+  "app_version": "0.1.0e",
   "schema_version": 2
 }

--- a/atlas/ingest_ascii.md
+++ b/atlas/ingest_ascii.md
@@ -1,11 +1,21 @@
 # ASCII Ingestion Pipeline
 
-- Parser: `load_ascii_spectrum` uses pandas with `sep=None` autodetection plus header/unit sniffing.
-- Column aliases: wavelength synonyms (`wavelength`, `lambda`, `nm`, `angstrom`), flux synonyms
-  (`flux`, `intensity`, `counts`), optional uncertainty column.
-- Units: header text inside parentheses/brackets parsed; defaults to nanometers when ambiguous.
+- Parser: `load_ascii_spectrum` still relies on pandas with `sep=None` autodetection but now reruns the
+  import without headers when the first row looks numeric, preventing leading data from being swallowed as
+  column labels.
+- Header canonicalisation: column labels are normalised into lowercase slugs (camelCase → snake_case,
+  punctuation/diacritics stripped) before alias matching to catch `FluxDensity`, `Wave Length`, etc.
+- Column detection: we still prefer explicit wavelength/flux aliases yet fall back to numeric heuristics
+  (monotonic ramp ≈ wavelength, remaining numeric column ≈ flux) so bare two-column exports are ingested
+  without renaming.
+- Units: header text inside parentheses/brackets parsed; when we guessed the columns, wavelength units are
+  reported as `unknown` to avoid leaking placeholder headers like `column_0`.
+- Row filtering: rows without finite wavelength/flux pairs are dropped after coercion; provenance logs the
+  total/retained counts so downstream tooling understands the trim.
 - Air/vac detection: regex search for "air" or "vacuum" in column name/unit; flagged in provenance.
-- Metadata scraping: optional columns (`target`, `object`, `instrument`, `telescope`, `observer`)
-  recorded into `TraceMetadata.extra` with `target`/`instrument`/`telescope` promoted.
+- Metadata scraping: alias map covers (`target`, `target_name`, `object`, `instrument_name`, etc.) with
+  null-like strings filtered; promoted into `TraceMetadata.target`/`instrument`/`telescope`.
 - Hash: SHA-256 of raw bytes stored for dedup ledger.
-- Provenance: `ingest_ascii` event includes filename, columns used, units, air flag, and content hash.
+- Provenance: `ingest_ascii` now records the detection strategy (`aliases` vs `numeric_heuristic`), whether
+  the upload was headerless, how many rows were retained, plus filename, columns, units, the air flag, and
+  content hash.

--- a/brains/v0.1.0d__assistant__ascii_resilience.md
+++ b/brains/v0.1.0d__assistant__ascii_resilience.md
@@ -1,0 +1,51 @@
+# v0.1.0d — ASCII ingestion resilience
+
+## Context
+- Goal: make ASCII uploads tolerant to messy export headers so wavelength/flux detection and metadata
+  extraction succeed without manual editing.
+- Starting point: v0.1.0c trimmed invisible characters but still missed camelCase, spaced, or dashed
+  headers (e.g. "FluxDensity", "Wave Length") and failed to harvest metadata aliases.
+
+## Changes
+- Added canonical header tokenisation that normalises casing, camel humps, punctuation, and diacritics
+  before alias matching in `server/ingest/ascii_loader.py`.
+- Expanded wavelength/flux alias sets and metadata synonym maps (Target/Object/Instrument/Telescope/
+  Observer) while filtering null-like string values.
+- Reworked label inference to prioritise target/object aliases and added regression coverage for messy
+  header combinations in `tests/test_ascii_loader.py`.
+
+## Decisions
+- Normalise metadata keys into canonical slugs rather than expanding ad-hoc alias lists throughout the
+  code so provenance remains consistent and easier to audit.
+- Treat "Object" fields as a fallback for `TraceMetadata.target`, preserving the original value in
+  `extra["object"]` for replay fidelity.
+- Skip null-like strings ("nan", "none", "null") when populating metadata to avoid polluting the
+  UI and provenance events.
+
+## Tests & Evidence
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`
+
+## Regressions Prevented
+- Ensures future ASCII ingest refactors continue to recognise camelCase or spaced wavelength/flux
+  headers and expanded metadata synonyms.
+- Prevents reintroducing null/"nan" metadata leakage into provenance which previously confused the
+  deduplication ledger and UI badges.
+
+## Follow-ups
+- Extend alias coverage to include uncertainty synonyms encountered in observatory exports (e.g.
+  "ErrFlux"), and add fixtures once samples arrive.
+- Investigate ingest-time unit normalisation for common flux conventions (erg/s/cm²/Å vs Jy).
+- Update Star Hub resolver to surface additional metadata fields exposed via the new alias map.
+
+## Checklist
+- [x] Atlas updated (`atlas/ingest_ascii.md`)
+- [x] Docs updated (patch notes, handoff)
+- [x] Tests updated (`tests/test_ascii_loader.py`)

--- a/brains/v0.1.0e__assistant__ascii_headerless.md
+++ b/brains/v0.1.0e__assistant__ascii_headerless.md
@@ -1,0 +1,57 @@
+# v0.1.0e — Headerless ASCII heuristics
+
+## Context
+- Goal: restore automatic column detection for ASCII uploads where exports omit descriptive headers or
+  include leading numeric rows.
+- Pain points: v0.1.0d required explicit wavelength/flux aliases, so headerless CSV files lost their first
+  data row to pandas' inferred header and ingestion failed, plus packaging metadata broke editable
+  installs (`0.1.0d0` was not PEP 440 compliant).
+
+## Changes
+- Added a headerless retry path that re-parses files without headers when the initial column labels are
+  numeric, assigning placeholder `column_*` names so we keep every data row.
+- Implemented numeric heuristics that score monotonic coverage to choose wavelength columns and select the
+  remaining numeric series as flux, with provenance noting the detection strategy, row counts, and whether
+  the upload lacked headers.
+- Coerced numeric columns safely, removed rows missing finite wavelength/flux pairs, and defaulted guessed
+  wavelength units to `unknown` instead of surfacing placeholder column labels.
+- Expanded regression coverage to assert headerless CSV ingestion, provenance metadata, and unit fallback.
+- Updated the ASCII ingest atlas entry to document the headerless retry, numeric heuristics, row trimming,
+  and provenance enrichments.
+- Bumped packaging metadata to `0.1.0.dev5` while the UI badge advances to `0.1.0e`, fixing pip editable
+  installs.
+
+## Decisions
+- Prefer monotonic numeric heuristics only when alias matching fails so we maintain backwards
+  compatibility for descriptive exports while rescuing bare numeric dumps.
+- Treat inferred wavelength units as `unknown` whenever the header is synthetic or numeric to avoid
+  exposing placeholder column names in the UI.
+- Record detection method, headerless flag, and retained row counts in provenance to aid debugging and
+  regression triage.
+- Adopt `0.1.0.dev5` in `pyproject.toml` while keeping the user-facing letter suffix so packaging remains
+  PEP 440 compliant without disrupting UI messaging.
+
+## Tests & Evidence
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`
+
+## Regressions Prevented
+- Prevents pandas from eating the first data row when uploads lack headers, ensuring wavelength/flux
+  arrays stay aligned with source files.
+- Avoids reintroducing bogus wavelength units (e.g., `column_0`) into provenance and downstream plots.
+- Guards against silent row-count mismatches by dropping invalid entries and surfacing retained totals.
+
+## Follow-ups
+- Monitor additional ASCII samples for descending or multi-segment wavelength patterns that may require
+  refined heuristics.
+- Evaluate numeric fallbacks for uncertainty columns once representative exports are available.
+- Draft UI guidance explaining the `unknown` unit badge when heuristics trigger.
+
+## Checklist
+- [x] Atlas updated (`atlas/ingest_ascii.md`)
+- [x] Patch notes & handoff updated (`PATCH_NOTES_v0.1.0(e).md`, `HANDOFF_v0.1.0(e).md`)
+- [x] Tests added/updated (`tests/test_ascii_loader.py`)

--- a/handoffs/HANDOFF_v0.1.0(d).md
+++ b/handoffs/HANDOFF_v0.1.0(d).md
@@ -1,0 +1,47 @@
+# HANDOFF 0.1.0d — ASCII ingestion resilience
+## 1) Summary of This Run
+- Normalised ASCII header tokens so wavelength/flux columns are detected even when exports use camel
+  case, embedded punctuation, or accented characters.
+- Expanded metadata alias detection (Target/Object/Instrument/Telescope/Observer) and filtered null-like
+  values to improve provenance and automatic trace labelling.
+- Added regression coverage for messy header combinations and updated docs/version artifacts for 0.1.0d.
+
+## 2) Current State of the Project
+- **Working tabs:** Overlay (ASCII+FITS with resilient header parsing), Differential, Star Hub (SIMBAD
+  resolver with fixtures), Docs.
+- **Known gaps:** Archive fetchers (MAST/SDSS) still stubbed; replay CLI/UI reconstruction pending;
+  docs tab remains a high-level overview.
+- **Performance:** Adequate for sample traces; ASCII ingest now spends negligible extra time on
+  canonicalisation.
+- **Debt:** Archive adapters, replay automation, ingest uncertainty alias expansion, accessibility
+  review for Docs tab.
+
+## 3) Next Steps (Prioritized)
+1) Implement archive fetchers (`server/fetchers/mast.py`, `server/fetchers/sdss.py`) with fixture-backed
+   tests to exercise the broadened metadata paths.
+2) Build the export replay CLI/UI reconstruction tooling, ensuring provenance reflects the new metadata
+   derivations.
+3) Extend uncertainty alias coverage (e.g. `ErrFlux`, `FluxErr`) and unit normalisation for common flux
+   conventions (erg/s/cm²/Å, Jy).
+
+## 4) Decisions & Rationale
+- Chose canonical slug tokenisation to unify header parsing instead of ad-hoc alias growth, improving
+  determinism and testability.
+- Treated "Object" fields as fallback targets to keep UI labelling stable when "Target" is absent while
+  still recording the original column in metadata extras.
+- Filtered null-like strings before writing metadata to prevent "nan" badges resurfacing in the UI or
+  provenance feeds.
+
+## 5) References
+- Atlas: `atlas/ingest_ascii.md`
+- Brains: `brains/v0.1.0d__assistant__ascii_resilience.md`
+- Patch notes: `PATCH_NOTES/PATCH_NOTES_v0.1.0(d).md`
+- Tests: `tests/test_ascii_loader.py`
+
+## 6) Quick Start for the Next AI
+- Install: `pip install -e .[dev]`
+- Run app: `streamlit run app/app_patched.py`
+- Quality gates: `ruff check .`, `black --check .`, `mypy .`, `python -m pytest`, then
+  `python tools/verifiers/Verify-*.py`
+- Sample data: ASCII (`data/examples/example_spectrum.csv`, messy header strings in tests), single-HDU
+  FITS (`data/examples/example_spectrum.fits`); tests synthesize SDSS-like fixtures.

--- a/handoffs/HANDOFF_v0.1.0(e).md
+++ b/handoffs/HANDOFF_v0.1.0(e).md
@@ -1,0 +1,41 @@
+# HANDOFF 0.1.0e — Headerless ASCII heuristics
+## 1) Summary of This Run
+- Added a headerless ingestion retry and numeric heuristics so ASCII uploads without descriptive headers
+  still auto-detect wavelength and flux columns.
+- Coerced numeric columns safely, dropped rows lacking finite wavelength/flux pairs, and exposed detection
+  method plus retained row counts in provenance for debugging.
+- Restored pip editable installs by bumping `pyproject.toml` to the PEP 440-compliant `0.1.0.dev5` while
+  advancing UI/version artifacts to `0.1.0e` with refreshed docs/tests.
+
+## 2) Current State of the Project
+- **Working tabs:** Overlay (ASCII+FITS, now with headerless numeric heuristics), Differential, Star Hub
+  (SIMBAD), Line Atlas, Upload history with provenance extras.
+- **Data ingestion:** FITS loader unchanged; ASCII loader handles messy headers, BOMs, metadata aliases,
+  and now bare numeric exports.
+- **Docs & comms:** Atlas article, patch notes, brains log, and handoff updated for v0.1.0e.
+
+## 3) Next Steps (Prioritized)
+1. Monitor additional real-world ASCII samples for multi-segment or unit edge cases that may need further
+   heuristics (e.g., wavelength decreasing, multi-flux columns).
+2. Evaluate whether uncertainty detection should get similar numeric fallback or interpolation handling.
+3. Plan UI messaging for `unknown` units when heuristics kick in (e.g., tooltip explaining the guess).
+
+## 4) Decisions & Rationale
+- Falling back to monotonic numeric heuristics prevents headerless exports from failing while still
+  prioritising explicit aliases when present.
+- Defaulting guessed wavelength units to `unknown` avoids exposing placeholder `column_*` labels in the UI.
+- Recording detection method, headerless flag, and retained row counts in provenance gives downstream tools
+  and QA visibility into the ingestion pathway.
+- Switching to `0.1.0.dev5` satisfies PEP 440 so CI/pip installs succeed without changing the user-facing
+  `0.1.0e` badge.
+
+## 5) References
+- Atlas: `atlas/ingest_ascii.md` (headerless retry & heuristic detection)
+- Patch notes: `PATCH_NOTES/PATCH_NOTES_v0.1.0(e).md`
+- Brains log: `brains/v0.1.0e__assistant__ascii_headerless.md`
+
+## 6) Quick Start for the Next AI
+- Install deps / run tests: `python -m pip install -e .` (now succeeds), `PYTHONPATH=. pytest -q`.
+- Verify artifacts: run the verifiers in `tools/verifiers` (PatchNotes, Brains, Handoff, Atlas, UI Contract).
+- Manual QA: upload headerless CSVs to confirm wavelength/flux detection, inspect provenance for
+  `detection_method="numeric_heuristic"` and `rows_retained` metadata.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectra-app"
-version = "0.1.0c0"
+version = "0.1.0.dev5"
 description = "Research-grade spectral comparison toolkit"
 readme = "README.md"
 authors = [{name = "Spectra App Team"}]

--- a/server/ingest/ascii_loader.py
+++ b/server/ingest/ascii_loader.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import hashlib
 import io
 import re
+import unicodedata
 from collections.abc import Iterable
 from dataclasses import dataclass
+from typing import Literal, overload
 
 import numpy as np
 import pandas as pd
@@ -17,6 +19,8 @@ _WAVE_ALIASES = {
     "wavelength",
     "wavelength_nm",
     "wavelength_air",
+    "wavelengths",
+    "wave_length",
     "lambda",
     "lambda_nm",
     "wl",
@@ -28,6 +32,7 @@ _WAVE_ALIASES = {
 _FLUX_ALIASES = {
     "flux",
     "flux_density",
+    "fluxdensity",
     "intensity",
     "counts",
     "flux_erg",
@@ -35,9 +40,23 @@ _FLUX_ALIASES = {
 }
 
 _UNCERTAINTY_ALIASES = {"uncertainty", "error", "sigma", "err", "flux_error"}
-_METADATA_COLUMNS = {"target", "object", "instrument", "telescope", "observer"}
+_METADATA_ALIAS_MAP: dict[str, tuple[str, ...]] = {
+    "target": ("target", "target_name", "name"),
+    "object": ("object", "object_name", "source", "source_name"),
+    "instrument": ("instrument", "instrument_name", "spectrograph"),
+    "telescope": ("telescope", "telescope_name", "observatory"),
+    "observer": ("observer", "observer_name", "pi", "principal_investigator"),
+}
 _UNIT_PATTERN = re.compile(r"(?P<name>[^()\[]+)(?:\s*[\[(](?P<unit>[^)\]]+)[)\]])?", re.IGNORECASE)
 _STANDARD_PATTERN = re.compile(r"(vacuum|air)", re.IGNORECASE)
+
+
+@dataclass(slots=True)
+class _NumericStats:
+    column: str
+    coverage: float
+    monotonic: float
+    span: float
 
 
 @dataclass(slots=True)
@@ -58,14 +77,39 @@ class ASCIIIngestError(RuntimeError):
     pass
 
 
+def _clean_header(column: str) -> str:
+    """Trim whitespace and strip invisible formatting characters."""
+
+    stripped = unicodedata.normalize("NFKC", column).strip()
+    if not stripped:
+        return stripped
+    # Remove zero-width and BOM characters that frequently appear in UTF-8 exports
+    cleaned = "".join(ch for ch in stripped if unicodedata.category(ch) != "Cf")
+    return cleaned
+
+
+def _canonicalise_name(name: str) -> str:
+    """Collapse a header or unit name into a canonical lookup token."""
+
+    if not name:
+        return ""
+    normalized = unicodedata.normalize("NFKC", name)
+    without_marks = "".join(ch for ch in normalized if unicodedata.category(ch) != "Mn")
+    with_separators = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", without_marks)
+    tokens = re.sub(r"[^0-9a-zA-Z]+", "_", with_separators.lower())
+    canonical = re.sub(r"_+", "_", tokens).strip("_")
+    return canonical
+
+
 def _normalise_header(column: str) -> tuple[str, str | None]:
-    match = _UNIT_PATTERN.match(column.strip())
+    cleaned = _clean_header(column)
+    match = _UNIT_PATTERN.match(cleaned)
     if not match:
-        return column.strip().lower(), None
-    name = match.group("name").strip().lower()
+        return _canonicalise_name(cleaned), None
+    name = match.group("name").strip()
     unit_raw = match.group("unit")
     unit = unit_raw.strip().lower() if unit_raw else None
-    return name, unit
+    return _canonicalise_name(name), unit
 
 
 def _detect_column(columns: Iterable[str], aliases: set[str]) -> str | None:
@@ -79,7 +123,7 @@ def _detect_column(columns: Iterable[str], aliases: set[str]) -> str | None:
 def _detect_standard(column: str, unit_hint: str | None) -> bool:
     """Return True if the column name/unit hints at air wavelengths."""
 
-    column_lc = column.lower()
+    column_lc = _clean_header(column).lower()
     if _STANDARD_PATTERN.search(column_lc):
         return "air" in column_lc
     if unit_hint and _STANDARD_PATTERN.search(unit_hint.lower()):
@@ -87,14 +131,244 @@ def _detect_standard(column: str, unit_hint: str | None) -> bool:
     return False
 
 
-def _infer_label(df: pd.DataFrame, filename: str) -> str:
-    for candidate in ("target", "object", "name"):
-        if candidate in df.columns and df[candidate].notna().any():
-            value = str(df[candidate].iloc[0]).strip()
-            if value:
-                return value
+def _column_lookup(columns: Iterable[str]) -> dict[str, str]:
+    """Map normalised column names to their original dataframe labels."""
+
+    lookup: dict[str, str] = {}
+    for column in columns:
+        key, _ = _normalise_header(column)
+        if key and key not in lookup:
+            lookup[key] = column
+    return lookup
+
+
+def _extract_first_value(series: pd.Series) -> str | float | int | None:
+    """Return the first non-null, non-empty value from a series."""
+
+    filtered = series.dropna()
+    if filtered.empty:
+        return None
+    value = filtered.iloc[0]
+    if isinstance(value, str):
+        trimmed = value.strip()
+        if not trimmed:
+            return None
+        lowered = trimmed.lower()
+        if lowered in {"nan", "none", "null"}:
+            return None
+        return trimmed
+    if pd.isna(value):
+        return None
+    return value
+
+
+def _select_column(column_lookup: dict[str, str], aliases: Iterable[str]) -> str | None:
+    for alias in aliases:
+        column = column_lookup.get(alias)
+        if column:
+            return column
+    return None
+
+
+def _build_metadata(df: pd.DataFrame, column_lookup: dict[str, str]) -> TraceMetadata:
+    metadata = TraceMetadata()
+    for key, aliases in _METADATA_ALIAS_MAP.items():
+        original = _select_column(column_lookup, aliases)
+        if original is None or original not in df.columns:
+            continue
+        value = _extract_first_value(df[original])
+        if value is None:
+            continue
+        metadata.extra[key] = value
+    metadata.target = metadata.extra.get("target") or metadata.extra.get("object")
+    metadata.instrument = metadata.extra.get("instrument")
+    metadata.telescope = metadata.extra.get("telescope")
+    return metadata
+
+
+_LABEL_PRIORITY = tuple(
+    dict.fromkeys(
+        _METADATA_ALIAS_MAP.get("target", ()) + _METADATA_ALIAS_MAP.get("object", ()) + ("name",)
+    )
+)
+
+
+def _infer_label(
+    df: pd.DataFrame, filename: str, column_lookup: dict[str, str] | None = None
+) -> str:
+    lookup = column_lookup or _column_lookup(df.columns)
+    for candidate in _LABEL_PRIORITY:
+        column = lookup.get(candidate)
+        if not column:
+            continue
+        value = _extract_first_value(df[column])
+        if value is not None:
+            return str(value)
     stem = filename.rsplit("/", 1)[-1]
     return stem.split(".")[0]
+
+
+def _is_numeric_token(token: str) -> bool:
+    token = token.strip()
+    if not token:
+        return False
+    try:
+        float(token)
+    except ValueError:
+        return False
+    return True
+
+
+def _looks_like_headerless(df: pd.DataFrame) -> bool:
+    if df.empty or not len(df.columns):
+        return False
+    tokens = [str(column) for column in df.columns]
+    numeric_like = sum(_is_numeric_token(token) for token in tokens)
+    unnamed_like = sum(token.lower().startswith("unnamed") for token in tokens)
+    if numeric_like == len(tokens):
+        return True
+    return numeric_like + unnamed_like >= len(tokens)
+
+
+def _numeric_column_stats(
+    df: pd.DataFrame, *, ensure: Iterable[str] | None = None
+) -> list[_NumericStats]:
+    ensured = set(ensure or ())
+    stats: list[_NumericStats] = []
+    for column in df.columns:
+        series = pd.to_numeric(df[column], errors="coerce")
+        total = len(series)
+        if total == 0:
+            continue
+        valid = series.dropna()
+        coverage = len(valid) / total if total else 0.0
+        if valid.empty:
+            if column in ensured:
+                stats.append(_NumericStats(column, coverage, 0.0, 0.0))
+            continue
+        if coverage < 0.4 and column not in ensured:
+            continue
+        values = valid.to_numpy(dtype=float)
+        if values.size > 1:
+            diffs = np.diff(values)
+            if diffs.size:
+                positive = float((diffs > 0).sum()) / diffs.size
+                negative = float((diffs < 0).sum()) / diffs.size
+                monotonic = max(positive, negative)
+            else:
+                monotonic = 0.0
+            span = float(abs(values[-1] - values[0]))
+        else:
+            monotonic = 0.0
+            span = 0.0
+        stats.append(_NumericStats(column, coverage, monotonic, span))
+    return stats
+
+
+def _choose_wave_column(stats: list[_NumericStats], existing: str | None) -> str:
+    if existing:
+        return existing
+    if not stats:
+        raise ASCIIIngestError("No wavelength column detected")
+    monotonic = [
+        candidate for candidate in stats if candidate.monotonic >= 0.6 and candidate.span > 0.0
+    ]
+    if monotonic:
+        ranked = sorted(
+            monotonic,
+            key=lambda item: (item.monotonic, item.coverage, item.span),
+            reverse=True,
+        )
+        return ranked[0].column
+    ranked = sorted(stats, key=lambda item: (item.coverage, item.span), reverse=True)
+    return ranked[0].column
+
+
+def _choose_flux_column(stats: list[_NumericStats], wave_column: str, existing: str | None) -> str:
+    if existing:
+        return existing
+    candidates = [item for item in stats if item.column != wave_column]
+    if not candidates:
+        raise ASCIIIngestError("No flux/intensity column detected")
+    ranked = sorted(
+        candidates,
+        key=lambda item: (item.coverage, -abs(item.monotonic - 0.5), item.span),
+        reverse=True,
+    )
+    return ranked[0].column
+
+
+@overload
+def _to_numeric_array(series: pd.Series, *, allow_empty: Literal[False] = False) -> np.ndarray: ...
+
+
+@overload
+def _to_numeric_array(series: pd.Series, *, allow_empty: Literal[True]) -> np.ndarray | None: ...
+
+
+def _to_numeric_array(series: pd.Series, *, allow_empty: bool = False) -> np.ndarray | None:
+    numeric = pd.to_numeric(series, errors="coerce")
+    valid_count = int(numeric.notna().sum())
+    if valid_count == 0:
+        if allow_empty:
+            return None
+        raise ASCIIIngestError(f"Column {series.name!r} contains no numeric data")
+    return numeric.to_numpy(dtype=float)
+
+
+def _read_ascii_dataframe(file_bytes: bytes) -> pd.DataFrame:
+    text = file_bytes.decode("utf-8", errors="replace")
+    buffer = io.StringIO(text)
+    try:
+        df = pd.read_csv(buffer, comment="#", sep=None, engine="python").dropna(how="all")
+    except Exception as exc:  # pragma: no cover - surfaced in tests
+        raise ASCIIIngestError(f"Failed to parse ASCII spectrum: {exc}") from exc
+
+    if df.empty:
+        return df
+
+    df.columns = [str(column) for column in df.columns]
+
+    if _looks_like_headerless(df):
+        buffer.seek(0)
+        df = pd.read_csv(
+            buffer,
+            comment="#",
+            sep=None,
+            engine="python",
+            header=None,
+        ).dropna(how="all")
+        df.columns = [f"column_{index}" for index in range(len(df.columns))]
+
+    df.columns = [str(column) for column in df.columns]
+    return df
+
+
+def _resolve_data_columns(
+    df: pd.DataFrame,
+) -> tuple[str, str, str | None, str]:
+    wave_column = _detect_column(df.columns, _WAVE_ALIASES)
+    flux_column = _detect_column(df.columns, _FLUX_ALIASES)
+    uncertainty_column = _detect_column(df.columns, _UNCERTAINTY_ALIASES)
+
+    detection_method = "aliases"
+    if wave_column is None or flux_column is None:
+        detection_method = "numeric_heuristic"
+        stats = _numeric_column_stats(
+            df,
+            ensure=[col for col in (wave_column, flux_column) if col is not None],
+        )
+        if len(stats) < 2 and (wave_column is None or flux_column is None):
+            raise ASCIIIngestError("No numeric columns detected")
+        wave_column = _choose_wave_column(stats, wave_column)
+        flux_column = _choose_flux_column(stats, wave_column, flux_column)
+
+    if wave_column is None:
+        raise ASCIIIngestError("No wavelength column detected")
+    if flux_column is None:
+        raise ASCIIIngestError("No flux/intensity column detected")
+
+    return wave_column, flux_column, uncertainty_column, detection_method
 
 
 def load_ascii_spectrum(file_bytes: bytes, filename: str) -> ASCIIIngestResult:
@@ -104,47 +378,39 @@ def load_ascii_spectrum(file_bytes: bytes, filename: str) -> ASCIIIngestResult:
         raise ASCIIIngestError("Empty file provided")
 
     content_hash = hashlib.sha256(file_bytes).hexdigest()
-    text = file_bytes.decode("utf-8", errors="replace")
-    buffer = io.StringIO(text)
-
-    try:
-        df = pd.read_csv(buffer, comment="#", sep=None, engine="python").dropna(how="all")
-    except Exception as exc:  # pragma: no cover - surfaced in tests
-        raise ASCIIIngestError(f"Failed to parse ASCII spectrum: {exc}") from exc
+    df = _read_ascii_dataframe(file_bytes)
 
     if df.empty:
         raise ASCIIIngestError("No rows detected in spectrum file")
 
-    wave_column = _detect_column(df.columns, _WAVE_ALIASES)
-    if wave_column is None:
-        raise ASCIIIngestError("No wavelength column detected")
-
-    flux_column = _detect_column(df.columns, _FLUX_ALIASES)
-    if flux_column is None:
-        raise ASCIIIngestError("No flux/intensity column detected")
-
-    uncertainty_column = _detect_column(df.columns, _UNCERTAINTY_ALIASES)
+    total_rows = int(len(df))
+    headerless = all(str(column).startswith("column_") for column in df.columns)
+    column_lookup = _column_lookup(df.columns)
+    wave_column, flux_column, uncertainty_column, detection_method = _resolve_data_columns(df)
 
     wave_name, wave_unit = _normalise_header(wave_column)
-    flux_name, flux_unit = _normalise_header(flux_column)
+    _, flux_unit = _normalise_header(flux_column)
     is_air = _detect_standard(wave_column, wave_unit)
 
-    wavelength = np.asarray(df[wave_column], dtype=float)
-    flux = np.asarray(df[flux_column], dtype=float)
+    wavelength = _to_numeric_array(df[wave_column])
+    flux = _to_numeric_array(df[flux_column])
+    valid_mask = np.isfinite(wavelength) & np.isfinite(flux)
+    if not np.any(valid_mask):
+        raise ASCIIIngestError("No overlapping numeric data between wavelength and flux columns")
+    if not np.all(valid_mask):
+        wavelength = wavelength[valid_mask]
+        flux = flux[valid_mask]
+    retained_rows = int(valid_mask.sum())
+
     uncertainties = None
     if uncertainty_column is not None:
-        uncertainties = np.asarray(df[uncertainty_column], dtype=float)
+        uncertainty_values = _to_numeric_array(df[uncertainty_column], allow_empty=True)
+        if uncertainty_values is not None:
+            if not np.all(valid_mask):
+                uncertainty_values = uncertainty_values[valid_mask]
+            uncertainties = uncertainty_values
 
-    metadata = TraceMetadata()
-    for column in _METADATA_COLUMNS:
-        if column in df.columns:
-            value = df[column].iloc[0]
-            if isinstance(value, str):
-                value = value.strip()
-            metadata.extra[column] = value
-    metadata.target = metadata.extra.get("target") or metadata.extra.get("object")
-    metadata.instrument = metadata.extra.get("instrument")
-    metadata.telescope = metadata.extra.get("telescope")
+    metadata = _build_metadata(df, column_lookup)
 
     provenance = [
         ProvenanceEvent(
@@ -157,17 +423,26 @@ def load_ascii_spectrum(file_bytes: bytes, filename: str) -> ASCIIIngestResult:
                 "wave_unit": wave_unit or "unknown",
                 "flux_unit": flux_unit or "unknown",
                 "is_air": is_air,
+                "detection_method": detection_method,
+                "headerless": headerless,
+                "rows_total": total_rows,
+                "rows_retained": retained_rows,
                 "hash": content_hash,
             },
         )
     ]
 
-    label = _infer_label(df, filename)
+    label = _infer_label(df, filename, column_lookup)
+
+    wave_header = _clean_header(str(wave_column))
+    wavelength_unit = wave_unit or wave_name
+    if not wavelength_unit or headerless or _is_numeric_token(wave_header):
+        wavelength_unit = "unknown"
 
     return ASCIIIngestResult(
         label=label,
         wavelength=wavelength,
-        wavelength_unit=wave_unit or wave_name,
+        wavelength_unit=wavelength_unit,
         flux=flux,
         flux_unit=flux_unit,
         uncertainties=uncertainties,

--- a/tests/test_ascii_loader.py
+++ b/tests/test_ascii_loader.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
+
 from app.state.session import AppSessionState
 from server.ingest.ascii_loader import load_ascii_spectrum
 from server.ingest.canonicalize import canonicalize_ascii
@@ -17,6 +19,35 @@ def test_ascii_loader_parses_units(tmp_path: Path) -> None:
     assert canonical.metadata.flux_units == "arb"
 
 
+def test_ascii_loader_handles_bom_headers() -> None:
+    content = "\ufeffWavelength (nm),Flux (arb),Target\n510.0,1.2,Example Object\n".encode()
+    result = load_ascii_spectrum(content, "bom.csv")
+    assert result.wavelength_unit == "nm"
+    assert result.metadata.target == "Example Object"
+    canonical = canonicalize_ascii(result)
+    assert canonical.metadata.target == "Example Object"
+
+
+def test_ascii_loader_handles_messy_synonyms() -> None:
+    content = b"\n".join(
+        [
+            b"Wave Length [Angstrom],FluxDensity,OBJECT NAME,Instrument Name,Telescope-name,Observer",
+            b"5100,1.23e-16,Messy Target,Messy Instrument,Messy Telescope,Astronomer",
+            b"",
+        ]
+    )
+    result = load_ascii_spectrum(content, "messy.csv")
+    assert result.wavelength_unit == "angstrom"
+    assert result.label == "Messy Target"
+    assert result.metadata.target == "Messy Target"
+    assert result.metadata.instrument == "Messy Instrument"
+    assert result.metadata.telescope == "Messy Telescope"
+    assert result.metadata.extra["observer"] == "Astronomer"
+    canonical = canonicalize_ascii(result)
+    assert canonical.metadata.target == "Messy Target"
+    assert canonical.metadata.instrument == "Messy Instrument"
+
+
 def test_session_deduplication() -> None:
     fixture = Path("data/examples/example_spectrum.csv")
     result = load_ascii_spectrum(fixture.read_bytes(), fixture.name)
@@ -27,3 +58,16 @@ def test_session_deduplication() -> None:
     added_again, duplicate_id = session.register_trace(canonical)
     assert not added_again
     assert duplicate_id == trace_id
+
+
+def test_ascii_loader_guesses_numeric_columns() -> None:
+    content = b"5100,1.23\n5110,1.19\n5120,1.17\n"
+    result = load_ascii_spectrum(content, "headerless.csv")
+    np.testing.assert_allclose(result.wavelength, np.array([5100.0, 5110.0, 5120.0]))
+    np.testing.assert_allclose(result.flux, np.array([1.23, 1.19, 1.17]))
+    assert result.wavelength_unit == "unknown"
+    assert result.label == "headerless"
+    params = result.provenance[0].parameters
+    assert params["detection_method"] == "numeric_heuristic"
+    assert params["headerless"]
+    assert params["rows_retained"] == 3


### PR DESCRIPTION
## Summary
- Retry ASCII ingestion without headers when the first row looks numeric, use coverage/monotonic heuristics to pick wavelength and flux columns, drop invalid rows, and capture the detection metadata in provenance.
- Add a regression that verifies headerless CSVs are ingested via the numeric heuristic, keep provenance flags, and surface an `unknown` wavelength unit.
- Document the headerless fallback in the atlas, bump the package to 0.1.0.dev5 / 0.1.0e, and publish the corresponding patch notes, brains entry, and handoff.

## Testing
- python -m pip install -e .
- ruff check .
- black --check .
- mypy .
- PYTHONPATH=. pytest -q
- python tools/verifiers/Verify-Atlas.py
- python tools/verifiers/Verify-Brains.py
- python tools/verifiers/Verify-PatchNotes.py
- python tools/verifiers/Verify-Handoff.py
- PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d31c3b9e688329b3719e5a895d663c