### PR TITLE
Surface transform provenance notes in overlay UI

### DIFF
--- a/PATCH_NOTES/PATCH_NOTES_v1.0.0(k).md
+++ b/PATCH_NOTES/PATCH_NOTES_v1.0.0(k).md
@@ -1,0 +1,33 @@
+# Spectra App v1.0.0 (k) — Transform provenance in the UI
+
+## Highlights
+- Extend the Overlay trace manager to summarise downstream provenance, including unit conversions,
+  air→vacuum corrections, and differential operations alongside the existing axis family badges.
+- Provide immediate visibility into how each trace was transformed after ingest so analysts can audit
+  derived spectra without exporting manifests.
+
+## Changes
+- Added transform-note extraction in the Overlay UI so axis captions now list unit conversions,
+  air-to-vacuum methods, and differential steps recorded in provenance events.
+- Expanded regression coverage verifying transform notes for air-wavelength uploads and differential
+  products so future changes keep the UI audit trail accurate.
+- Updated documentation, atlas UI contract, brains log, handoff, and version metadata to advertise
+  `1.0.0k` / `1.0.0.dev11` with the new provenance summaries.
+
+## Known Issues
+- Archive fetchers (MAST/SDSS) remain stubbed; Star Hub still relies on fixtures.
+- Replay CLI/UI reconstruction tooling and richer docs content remain outstanding.
+- Provenance summaries cover ingestion, conversions, and differentials; future runs may extend them to
+  other transforms (e.g., resolution matching) as those events are recorded.
+
+## Verification
+- `python -m pip install -e .`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`

--- a/app/config/version.json
+++ b/app/config/version.json
@@ -1,4 +1,4 @@
 {
-  "app_version": "1.0.0j",
+  "app_version": "1.0.0k",
   "schema_version": 2
 }

--- a/atlas/ui_contract.md
+++ b/atlas/ui_contract.md
@@ -3,8 +3,9 @@
 - Tabs: Overlay, Differential, Star Hub, Docs (verified via `get_ui_contract`).
 - Sidebar order: Examples → Display Mode → Units → Duplicate Scope → Line Overlays.
 - Header: title, version badge (`app_version`), global search field, export button below tabs.
-- Overlay tab: file uploader, trace manager checkboxes with axis-family captions, Plotly chart with
-  secondary axis for line overlays, provenance caption.
+- Overlay tab: file uploader, trace manager checkboxes with axis-family captions and transform provenance
+  (unit conversions, air↔vacuum, differential events), Plotly chart with secondary axis for line overlays,
+  provenance caption.
 - Differential tab: select boxes for trace A/B, buttons for subtraction and ratio with identical
   suppression messaging.
 - Star Hub: SIMBAD resolver card placeholder; future runs expand provider grid.

--- a/brains/v1.0.0k__assistant__transform_provenance_ui.md
+++ b/brains/v1.0.0k__assistant__transform_provenance_ui.md
@@ -1,0 +1,55 @@
+# v1.0.0k — Transform provenance surfaced in the UI
+
+## Context
+- Goal: extend the Overlay trace manager to expose downstream provenance (unit conversions, air↔vacuum,
+  differential math) so analysts can audit how each spectrum was transformed without exporting bundles.
+- Prior state: the UI displayed axis-family badges but required manifest inspection to understand
+  subsequent conversions or differential operations.
+
+## Changes
+- Added transform-note extraction in `app/ui/overlay.py`, rendering unit conversions, air→vacuum
+  corrections, and differential steps beneath each trace checkbox.
+- Expanded regression coverage in `tests/test_overlay_axis_summary.py` for air-wavelength uploads and
+  differential products to keep the UI audit trail deterministic.
+- Updated docs (overview + atlas UI contract), patch notes, handoff, and version metadata to ship
+  `1.0.0k` / `1.0.0.dev11` describing the new provenance summaries.
+
+## Decisions
+- Reused existing provenance events instead of minting new metadata, ensuring historical traces benefit
+  immediately and keeping manifests stable.
+- Displayed transform notes inline with axis captions to keep the provenance context adjacent to the
+  visibility controls analysts already use.
+- Formatted epsilon values with general notation (`{epsilon:g}`) for compact readability while retaining
+  numeric fidelity.
+
+## Tests & Evidence
+- `python -m pip install -e .`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`
+
+## Regressions Prevented
+- Analysts immediately see whether an upload underwent air→vacuum conversion or differential math,
+  avoiding misinterpretation of derived traces during live review sessions.
+- Axis-unit conversions are now evident in the UI, preventing confusion when uploads arrive in Angstroms
+  or frequency/energy units.
+- Differential operations log their operands and epsilon values inline, making it clear how a derived
+  trace was constructed.
+
+## Follow-ups
+- Extend provenance display to cover future transform events (e.g., resolution matching) once they record
+  dedicated `ProvenanceEvent` entries.
+- Broaden Docs tab content to include troubleshooting scenarios that reference the new UI provenance
+  cues.
+- Continue archive fetcher development so real-world products exercise the enhanced provenance display.
+
+## Checklist
+- [x] Atlas updated (`atlas/ui_contract.md`)
+- [x] Patch notes & handoff updated (`PATCH_NOTES_v1.0.0(k).md`, `HANDOFF_v1.0.0(k).md`)
+- [x] Tests added/updated (`tests/test_overlay_axis_summary.py`)

--- a/docs/static/overview.md
+++ b/docs/static/overview.md
@@ -11,8 +11,9 @@ and exporting manifests that replay the current view. The current build includes
 - Fe I line overlays with scaling controls plus an offline SIMBAD resolver fixture.
 - Frequency- and energy-based uploads (Hz–PHz, eV/keV/MeV) auto-convert to the wavelength baseline
   during ingest, with provenance capturing the detected axis family.
-- Overlay trace manager surfaces the detected axis family, units, and detection method for each trace to
-  speed up debugging of messy uploads.
+- Overlay trace manager surfaces the detected axis family, units, detection method, and downstream
+  transforms (unit conversions, air↔vacuum shifts, differential operations) to speed up debugging of
+  messy uploads and derived products.
 
 Upcoming documentation work will expand this section with end-to-end usage guidance, data-source
 citation details, legal notices, and troubleshooting tips.

--- a/handoffs/HANDOFF_v1.0.0(k).md
+++ b/handoffs/HANDOFF_v1.0.0(k).md
@@ -1,0 +1,42 @@
+# HANDOFF 1.0.0k — Transform provenance surfaced in UI
+
+## 1) Summary of This Run
+- Overlay trace manager now lists downstream provenance (unit conversions, air→vacuum steps, differential
+  operations) alongside the axis-family captions so analysts can audit transforms without exporting.
+- Regression coverage exercises the new transform notes for air-wavelength ASCII uploads and derived
+  differential spectra to keep the UI summaries trustworthy.
+- Documentation, patch notes, brains log, and metadata advertise `1.0.0k` / `1.0.0.dev11` and describe
+  the expanded provenance display.
+
+## 2) Current State of the Project
+- **Working tabs:** Overlay (axis and transform provenance captions, line overlays, export), Differential,
+  Star Hub (SIMBAD resolver placeholder), Line Atlas, Docs.
+- **Data ingestion:** ASCII/FITS loaders classify axis family, detect air vs vacuum, and log provenance
+  events consumed by the UI transform summaries.
+- **Docs & comms:** Atlas UI contract, overview doc, patch notes, brains log, and this handoff reflect the
+  new UI provenance behaviour.
+
+## 3) Next Steps (Prioritized)
+1. Extend provenance display once additional transforms (e.g., resolution matching) emit events.
+2. Continue archive fetcher build-out so real products exercise the enhanced UI provenance trail.
+3. Expand Docs tab content with troubleshooting guidance referencing the new captions.
+
+## 4) Decisions & Rationale
+- Reused existing provenance event payloads, avoiding schema changes and ensuring historical traces gain
+  UI visibility immediately.
+- Rendered transform notes inline with axis captions to keep context close to the visibility toggles used
+  during analysis sessions.
+- Formatted epsilon parameters succinctly so long differential chains remain readable in the sidebar.
+
+## 5) References
+- Patch notes: `PATCH_NOTES/PATCH_NOTES_v1.0.0(k).md`
+- Brains log: `brains/v1.0.0k__assistant__transform_provenance_ui.md`
+- Atlas: `atlas/ui_contract.md`
+
+## 6) Quick Start for the Next AI
+- Install deps / smoke: `python -m pip install -e .`, `PYTHONPATH=. pytest -q`.
+- Static checks: `ruff check .`, `black --check .`, `mypy .`.
+- Verifiers: `python tools/verifiers/Verify-Atlas.py`, `Verify-PatchNotes.py`, `Verify-Brains.py`,
+  `Verify-Handoff.py`, `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`.
+- Manual QA: upload Angstrom-labelled ASCII files or compute differentials and confirm the transform
+  caption lists conversions, air→vacuum corrections, and differential operations inline beneath the trace.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectra-app"
-version = "1.0.0.dev10"
+version = "1.0.0.dev11"
 
 description = "Research-grade spectral comparison toolkit"
 readme = "README.md"

--- a/tests/test_overlay_axis_summary.py
+++ b/tests/test_overlay_axis_summary.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from app.ui.overlay import _extract_axis_summary, _format_axis_caption
+from app.ui.overlay import (
+    _collect_transform_notes,
+    _extract_axis_summary,
+    _format_axis_caption,
+)
 from server.ingest.ascii_loader import load_ascii_spectrum
 from server.ingest.canonicalize import canonicalize_ascii, canonicalize_fits
 from server.ingest.fits_loader import load_fits_spectrum
+from server.math.differential import subtract
+from server.models import ProvenanceEvent
 
 
 def test_axis_summary_for_ascii_trace() -> None:
@@ -50,3 +56,32 @@ def test_axis_summary_for_fits_trace() -> None:
 
     caption = _format_axis_caption(summary)
     assert "via fits" in caption
+
+
+def test_transform_notes_include_axis_conversions() -> None:
+    content = b"Wavelength_air (angstrom),Flux\n5100,1.0\n5110,0.9\n"
+    result = load_ascii_spectrum(content, "air_units.csv")
+    canonical = canonicalize_ascii(result)
+
+    notes = _collect_transform_notes(canonical)
+    assert any(note.startswith("Axis converted") for note in notes)
+    assert any("Air→vacuum" in note for note in notes)
+
+
+def test_transform_notes_include_differential_events() -> None:
+    fixture = Path("data/examples/example_spectrum.csv")
+    base_result = load_ascii_spectrum(fixture.read_bytes(), fixture.name)
+    base = canonicalize_ascii(base_result)
+    offset_content = b"Wavelength (nm),Flux (arb),target\n500.0,0.9,Example Star\n500.5,1.0,Example Star\n501.0,0.8,Example Star\n501.5,0.95,Example Star\n502.0,1.1,Example Star\n"
+    offset_result = load_ascii_spectrum(offset_content, "offset.csv")
+    other = canonicalize_ascii(offset_result)
+
+    product = subtract(base, other)
+    assert product is not None
+    product.spectrum.provenance.append(
+        ProvenanceEvent(step="differential_ui_add", parameters={"operation": product.operation})
+    )
+
+    notes = _collect_transform_notes(product.spectrum)
+    assert any(note.startswith("Differential subtract") for note in notes)
+    assert any("Added via differential tab" in note for note in notes)


### PR DESCRIPTION
## Summary
- surface downstream provenance notes (unit conversions, air↔vacuum, differential ops) beneath each trace in the Overlay manager
- expand overlay tests to cover transform notes and air-wavelength uploads
- bump version to 1.0.0k / 1.0.0.dev11 and refresh docs, brains, patch notes, and handoff to describe the new UI behaviour

## Testing
- python -m pip install -e .
- ruff check .
- black --check .
- mypy .
- PYTHONPATH=. pytest -q
- python tools/verifiers/Verify-Atlas.py
- python tools/verifiers/Verify-PatchNotes.py
- python tools/verifiers/Verify-Handoff.py
- python tools/verifiers/Verify-Brains.py
- PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d557e43210832990152b771ec86091