### PR TITLE
Implement archive fetchers for MAST and SDSS

### DIFF
--- a/PATCH_NOTES/PATCH_NOTES_v1.0.0(l).md
+++ b/PATCH_NOTES/PATCH_NOTES_v1.0.0(l).md
@@ -1,0 +1,28 @@
+# Spectra App v1.0.0 (l) — Archive fetchers come online
+
+## Highlights
+- Implemented working archive adapters for MAST and SDSS so Star Hub can surface real spectroscopic products instead of placeholders.
+- Added offline regression coverage for the new fetchers, exercising wavelength/range normalisation, metadata capture, and download link assembly without network access.
+- Documented the fetcher pipeline in the atlas and bumped version metadata to `1.0.0l` / `1.0.0.dev12`.
+
+## Changes
+- Replaced the stubbed MAST adapter with an `astroquery`-backed search that filters spectroscopic observations, normalises wavelength coverage to nanometres, and captures provenance plus direct download URIs.
+- Delivered SDSS helpers that resolve spectra by SpecObjID or plate/MJD/fibre, derive wavelength coverage/resolution from FITS tables, and expose canonical flux units and portal/download links.
+- Added targeted pytest coverage for both adapters using synthetic `astroquery` stubs and extended the atlas fetcher overview with the new data flow.
+
+## Known Issues
+- Fetchers currently return metadata and download URLs; live ingestion into the overlay tab will be wired up in a follow-up once the UI plumbing is prepared.
+- Network access remains optional; integration environments without `astroquery` will still need stubs or cached results to exercise full paths.
+- Replay tooling and richer documentation continue to track as open items from earlier runs.
+
+## Verification
+- `python -m pip install -e .`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`

--- a/atlas/fetchers_overview.md
+++ b/atlas/fetchers_overview.md
@@ -3,6 +3,15 @@
 - Resolver: `server/fetchers/resolver_simbad.resolve` uses astroquery when available; falls back to
   bundled `simbad_m31.json` fixture for offline tests.
 - Product model: `server/fetchers/models.py` defines `Product` and `ResolverResult` dataclasses.
-- MAST/SDSS adapters currently stubbed (raise `NotImplementedError`), documenting future expansion
-  path without breaking import graph.
-- Tests rely on fixture path; network lookups optional.
+- MAST: `server/fetchers/mast.search_products` queries the archive via `astroquery.mast.Observations`
+  when available, filtering for spectroscopic products and augmenting metadata with direct download
+  URIs from the product list. The adapter normalises wavelength bounds to nanometres, extracts
+  pipeline provenance, and records auxiliary fields (collection, filters, exposure) in the `extra`
+  payload. Offline tests monkeypatch the client to avoid network access while exercising the
+  canonicalisation path.
+- SDSS: `server/fetchers/sdss.fetch_by_specobjid` / `fetch_by_plate` resolve metadata through
+  `astroquery.sdss.SDSS.query_specobj`, pull the calibrated spectrum via `get_spectra`, and derive
+  wavelength coverage/resolution from the FITS table. Products advertise vacuum wavelengths,
+  standard SDSS flux units (`1e-17 erg s^-1 cm^-2 Å^-1`), and include canonical download/portal
+  links. Offline coverage patches the SDSS client with synthetic tables/HDU lists.
+- Tests rely on local fixtures/stubs; network lookups remain optional for integration runs.

--- a/brains/v1.0.0l__assistant__archive_fetchers.md
+++ b/brains/v1.0.0l__assistant__archive_fetchers.md
@@ -1,0 +1,43 @@
+# v1.0.0l — Archive fetchers online
+
+## Context
+- Star Hub previously listed only resolver output because the MAST and SDSS adapters were stubbed.
+- Frequency/energy ingestion landed last run; we now need credible archive metadata to exercise those paths.
+
+## Changes
+- Implemented `server/fetchers/mast.search_products` using `astroquery.mast.Observations`, normalising wavelength bounds, collecting provenance, and constructing download links from product lists.
+- Built `server/fetchers/sdss.fetch_by_specobjid` / `fetch_by_plate` to query SDSS metadata, fetch calibrated spectra via `get_spectra`, and derive wavelength coverage and resolving power from FITS tables.
+- Added regression tests (`tests/test_fetchers_mast.py`, `tests/test_fetchers_sdss.py`) that monkeypatch astroquery clients with synthetic tables/HDU lists to validate normalisation without network access.
+- Updated `atlas/fetchers_overview.md`, bumped `pyproject.toml` to `1.0.0.dev12`, and recorded the run in patch notes and handoff.
+
+## Decisions
+- Treated MAST wavelength bounds as metres when below 1e-2 to safely normalise to nanometres without double-scaling typical nm values.
+- Surfaced standard SDSS flux units (`1e-17 erg s^-1 cm^-2 Å^-1`) explicitly while leaving DOI fields null until product-level identifiers are available.
+- Closed surplus FITS handles defensively after extracting metadata to avoid file descriptor leaks during batch fetches.
+
+## Tests & Evidence
+- `python -m pip install -e .`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`
+
+## Regressions Prevented
+- Ensures future archive work has deterministic wavelength/resolution metadata, guarding against misclassified coverage or missing download links.
+- Provides offline safety so CI failures won't arise when astroquery or network access is unavailable.
+
+## Follow-ups
+- Wire the new Product outputs into the Star Hub UI and ingestion pipeline so analysts can pull spectra directly into overlays.
+- Expand DOI/citation capture once mission-specific metadata is catalogued.
+- Evaluate caching strategies for frequently accessed products to reduce redundant archive calls.
+
+## Checklist
+- [x] Atlas updated (`atlas/fetchers_overview.md`)
+- [x] Patch notes added (`PATCH_NOTES/PATCH_NOTES_v1.0.0(l).md`)
+- [x] Handoff updated (`handoffs/HANDOFF_v1.0.0(l).md`)
+- [x] Tests added (`tests/test_fetchers_mast.py`, `tests/test_fetchers_sdss.py`)

--- a/handoffs/HANDOFF_v1.0.0(l).md
+++ b/handoffs/HANDOFF_v1.0.0(l).md
@@ -1,0 +1,33 @@
+# HANDOFF 1.0.0l — Archive fetchers online
+
+## 1) Summary of This Run
+- Delivered operational MAST and SDSS adapters that return real spectroscopic product metadata with wavelength bounds, provenance, and download links.
+- Added regression suites with synthetic astroquery stubs so CI can validate the normalisation logic without network access.
+- Updated atlas/brains/patch notes/handoff plus version metadata to advertise `1.0.0l` / `1.0.0.dev12`.
+
+## 2) Current State of the Project
+- **Working tabs:** Overlay (axis + transform provenance captions, line overlays, export), Differential, Star Hub (SIMBAD resolver + new archive metadata), Line Atlas, Docs.
+- **Data ingestion:** ASCII/FITS loaders cover wavelength, wavenumber, frequency, and energy axes with provenance logging.
+- **Fetchers:** SIMBAD resolver with fixture fallback; MAST + SDSS adapters return spectroscopic `Product` entries with coverage/resolution estimates and canonical links.
+- **Docs & comms:** Atlas fetcher overview, patch notes, brains journal, and this handoff document the archive work.
+
+## 3) Next Steps (Prioritized)
+1. Thread the new `Product` outputs into the Star Hub UI so analysts can add archive spectra directly to overlays.
+2. Capture mission-specific citations/DOIs when archives expose them and bubble attribution into manifests.
+3. Evaluate caching / retry strategies for archive calls to improve resilience when network access is intermittent.
+
+## 4) Decisions & Rationale
+- Normalised MAST wavelength bounds assuming metre inputs when values are <1e-2, which covers published catalogue scales without double-counting nm ranges.
+- Declared SDSS flux units explicitly (`1e-17 erg s^-1 cm^-2 Å^-1`) while leaving DOI fields empty pending authoritative identifiers.
+- Closed extra FITS handles returned by astroquery to avoid descriptor leaks in long-lived sessions.
+
+## 5) References
+- Patch notes: `PATCH_NOTES/PATCH_NOTES_v1.0.0(l).md`
+- Brains log: `brains/v1.0.0l__assistant__archive_fetchers.md`
+- Atlas: `atlas/fetchers_overview.md`
+
+## 6) Quick Start for the Next AI
+- Install deps / smoke: `python -m pip install -e .`, `PYTHONPATH=. pytest -q`.
+- Static checks: `ruff check .`, `black --check .`, `mypy .`.
+- Verifiers: `python tools/verifiers/Verify-Atlas.py`, `Verify-PatchNotes.py`, `Verify-Brains.py`, `Verify-Handoff.py`, `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`.
+- Manual QA: invoke the new fetchers (MAST search by RA/Dec, SDSS by SpecObjID) and confirm wavelength coverage/resolution metadata look plausible with working download links.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectra-app"
-version = "1.0.0.dev11"
+version = "1.0.0.dev12"
 
 description = "Research-grade spectral comparison toolkit"
 readme = "README.md"

--- a/server/fetchers/mast.py
+++ b/server/fetchers/mast.py
@@ -1,13 +1,247 @@
-"""MAST archive adapter placeholder."""
+"""MAST archive adapter implementation."""
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
+from typing import Any
+
+import numpy as np
+from astropy import units as u
+from astropy.coordinates import SkyCoord
+from astropy.table import Table
+
+try:  # pragma: no cover - network path exercised in integration runs
+    from astroquery.mast import Observations
+except Exception:  # pragma: no cover - astroquery optional during tests
+    Observations = None  # type: ignore[assignment]
 
 from server.fetchers.models import Product
 
+_SPECTRUM_TYPES = {"spectrum"}
+_DOWNLOAD_ROOT = "https://mast.stsci.edu/api/v0.1/Download/file?uri={uri}"
+
+
+def _is_masked(value: Any) -> bool:
+    mask = getattr(value, "mask", None)
+    if mask is None:
+        return False
+    if mask is np.ma.nomask:  # type: ignore[attr-defined]
+        return False
+    try:
+        return bool(np.all(mask))
+    except Exception:
+        return bool(mask)
+
+
+def _raw(row: Table | Any, key: str) -> Any | None:
+    if key not in getattr(row, "colnames", []):
+        return None
+    value = row[key]
+    if _is_masked(value):
+        return None
+    return value
+
+
+def _coerce_scalar(value: Any) -> Any | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="ignore")
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "item") and not isinstance(value, str | bytes):
+        size = getattr(value, "size", None)
+        if size == 1:
+            return value.item()
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
+def _to_float(value: Any, *, unit: u.Unit | None = None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, u.Quantity):
+        try:
+            if unit is not None:
+                return float(value.to(unit).value)
+            return float(value.to_value())
+        except Exception:
+            return None
+    coerced = _coerce_scalar(value)
+    if coerced is None:
+        return None
+    try:
+        result = float(coerced)
+    except (TypeError, ValueError):
+        return None
+    if np.isnan(result):
+        return None
+    return result
+
+
+def _to_str(value: Any) -> str | None:
+    coerced = _coerce_scalar(value)
+    if coerced is None:
+        return None
+    return str(coerced)
+
+
+def _length_to_nm(value: Any) -> float | None:
+    if isinstance(value, u.Quantity):
+        try:
+            return float(value.to(u.nm).value)
+        except Exception:
+            try:
+                return float(value.to(u.m).value) * 1e9
+            except Exception:
+                return None
+    numeric = _to_float(value)
+    if numeric is None:
+        return None
+    if numeric <= 0:
+        return None
+    if numeric < 1e-2:  # assume metres
+        return numeric * 1e9
+    return numeric
+
+
+def _wave_range(row: Table | Any) -> tuple[float, float] | None:
+    em_min = _length_to_nm(_raw(row, "em_min"))
+    em_max = _length_to_nm(_raw(row, "em_max"))
+    if em_min is None or em_max is None:
+        return None
+    return (em_min, em_max)
+
+
+def _resolution(row: Table | Any) -> float | None:
+    for key in ("s_resolution", "resolution", "specres", "resolpower"):
+        value = _to_float(_raw(row, key))
+        if value is not None and value > 0:
+            return value
+    return None
+
+
+def _collect_urls(row: Table | Any) -> dict[str, str]:
+    urls: dict[str, str] = {}
+    preview = _to_str(_raw(row, "jpegURL")) or _to_str(_raw(row, "previewURL"))
+    if preview:
+        urls["preview"] = preview
+    product_url = _to_str(_raw(row, "dataURL"))
+    if product_url:
+        urls["product"] = product_url
+    return urls
+
+
+def _augment_with_product_list(urls: dict[str, str], obs_identifier: Any) -> None:
+    if Observations is None:
+        return
+    try:
+        product_table = Observations.get_product_list(obs_identifier)
+    except Exception:  # pragma: no cover - network failure handled gracefully
+        return
+    if product_table is None:
+        return
+    for row in product_table:
+        dtype = _to_str(_raw(row, "dataproduct_type"))
+        if dtype is None or dtype.lower() not in _SPECTRUM_TYPES:
+            continue
+        product_type = _to_str(_raw(row, "productType"))
+        if product_type and product_type.upper() not in {"SCIENCE", "CALIBRATION"}:
+            continue
+        data_uri = _to_str(_raw(row, "dataURI"))
+        if not data_uri:
+            continue
+        urls.setdefault("download", _DOWNLOAD_ROOT.format(uri=data_uri))
+        description = _to_str(_raw(row, "description"))
+        if description:
+            urls.setdefault("description", description)
+
+
+def _extra_metadata(row: Table | Any) -> dict[str, Any]:
+    fields = [
+        "obs_collection",
+        "instrument_name",
+        "filters",
+        "proposal_id",
+        "proposal_pi",
+        "t_exptime",
+        "dataRights",
+    ]
+    extra: dict[str, Any] = {}
+    for field in fields:
+        value = _raw(row, field)
+        if value is None:
+            continue
+        if field == "t_exptime":
+            numeric = _to_float(value)
+            if numeric is not None:
+                extra[field] = numeric
+            continue
+        coerced = _coerce_scalar(value)
+        if coerced is not None:
+            extra[field] = coerced
+    return extra
+
+
+def _rows_to_products(rows: Table) -> Iterator[Product]:
+    for row in rows:
+        dtype = _to_str(_raw(row, "dataproduct_type"))
+        if dtype is not None and dtype.lower() not in _SPECTRUM_TYPES:
+            continue
+        obs_identifier = _raw(row, "obsid")
+        product_id = _to_str(obs_identifier) or _to_str(_raw(row, "obs_id"))
+        if product_id is None:
+            continue
+        title = _to_str(_raw(row, "obs_title")) or _to_str(_raw(row, "target_name")) or product_id
+        target = _to_str(_raw(row, "target_name"))
+        ra = _to_float(_raw(row, "s_ra"), unit=u.deg)
+        dec = _to_float(_raw(row, "s_dec"), unit=u.deg)
+        wave_range = _wave_range(row)
+        resolution = _resolution(row)
+        pipeline_version = _to_str(_raw(row, "provenance_name")) or _to_str(
+            _raw(row, "instrument_name")
+        )
+        urls = _collect_urls(row)
+        if obs_identifier is not None:
+            _augment_with_product_list(urls, obs_identifier)
+        doi = _to_str(_raw(row, "data_doi")) or _to_str(_raw(row, "obs_doi"))
+        citation = _to_str(_raw(row, "obs_collection"))
+        yield Product(
+            provider="MAST",
+            product_id=product_id,
+            title=title,
+            target=target,
+            ra=ra,
+            dec=dec,
+            wave_range_nm=wave_range,
+            resolution_R=resolution,
+            wavelength_standard="unknown",
+            flux_units=_to_str(_raw(row, "flux_units")) or _to_str(_raw(row, "fluxunit")),
+            pipeline_version=pipeline_version,
+            urls=urls,
+            citation=citation,
+            doi=doi,
+            extra=_extra_metadata(row),
+        )
+
 
 def search_products(*, ra: float, dec: float, radius_arcsec: float = 5.0) -> Iterable[Product]:
-    """Search the MAST archive (placeholder)."""
+    """Search the MAST archive for spectroscopic products."""
 
-    raise NotImplementedError("MAST adapter pending future implementation")
+    if Observations is None:
+        raise RuntimeError("astroquery.mast is not available")
+
+    coord = SkyCoord(ra=ra * u.deg, dec=dec * u.deg)
+    radius = radius_arcsec * u.arcsec
+    try:
+        table = Observations.query_region(coord, radius=radius)
+    except Exception as exc:  # pragma: no cover - depends on network access
+        raise RuntimeError("MAST query failed") from exc
+    if table is None or len(table) == 0:
+        return []
+    return tuple(_rows_to_products(table))
+
+
+__all__ = ["search_products"]

--- a/server/fetchers/sdss.py
+++ b/server/fetchers/sdss.py
@@ -1,13 +1,247 @@
-"""SDSS spectral fetcher placeholder."""
+"""SDSS spectral fetcher implementation."""
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from contextlib import suppress
+from typing import Any
+
+import numpy as np
+from astropy import units as u
+from astropy.io import fits
+from astropy.table import Table
+
+try:  # pragma: no cover - network exercised separately
+    from astroquery.sdss import SDSS
+except Exception:  # pragma: no cover - astroquery optional during tests
+    SDSS = None  # type: ignore[assignment]
+
 from server.fetchers.models import Product
+
+_FLUX_UNITS = "1e-17 erg s^-1 cm^-2 Å^-1"
+
+
+def _is_masked(value: Any) -> bool:
+    mask = getattr(value, "mask", None)
+    if mask is None:
+        return False
+    if mask is np.ma.nomask:  # type: ignore[attr-defined]
+        return False
+    try:
+        return bool(np.all(mask))
+    except Exception:
+        return bool(mask)
+
+
+def _raw(row: Table | Any, key: str) -> Any | None:
+    if key not in getattr(row, "colnames", []):
+        return None
+    value = row[key]
+    if _is_masked(value):
+        return None
+    return value
+
+
+def _coerce_scalar(value: Any) -> Any | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="ignore")
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "item") and not isinstance(value, str | bytes):
+        size = getattr(value, "size", None)
+        if size == 1:
+            return value.item()
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return value
+
+
+def _to_float(value: Any, *, unit: u.Unit | None = None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, u.Quantity):
+        try:
+            if unit is not None:
+                return float(value.to(unit).value)
+            return float(value.to_value())
+        except Exception:
+            return None
+    coerced = _coerce_scalar(value)
+    if coerced is None:
+        return None
+    try:
+        result = float(coerced)
+    except (TypeError, ValueError):
+        return None
+    if np.isnan(result):
+        return None
+    return result
+
+
+def _to_int(value: Any) -> int | None:
+    numeric = _to_float(value)
+    if numeric is None:
+        return None
+    return int(round(numeric))
+
+
+def _to_str(value: Any) -> str | None:
+    coerced = _coerce_scalar(value)
+    if coerced is None:
+        return None
+    return str(coerced)
+
+
+def _extract_wave_range(hdul: fits.HDUList) -> tuple[float, float] | None:
+    for key in ("COADD", 1):
+        if key not in hdul:
+            continue
+        data = hdul[key].data
+        if data is None or "loglam" not in data.dtype.names:
+            continue
+        loglam = np.array(data["loglam"], dtype=float)
+        if loglam.size == 0:
+            continue
+        lam_angstrom = np.power(10.0, loglam)
+        lam_nm = lam_angstrom * 0.1
+        return (float(np.min(lam_nm)), float(np.max(lam_nm)))
+    return None
+
+
+def _estimate_resolution(hdul: fits.HDUList) -> float | None:
+    for key in ("COADD", 1):
+        if key not in hdul:
+            continue
+        data = hdul[key].data
+        if data is None or "loglam" not in data.dtype.names:
+            continue
+        loglam = np.array(data["loglam"], dtype=float)
+        if loglam.size < 2:
+            continue
+        diffs = np.diff(loglam)
+        positive = diffs[diffs > 0]
+        if positive.size == 0:
+            continue
+        delta_log = float(np.median(positive))
+        lam_angstrom = float(np.median(np.power(10.0, loglam)))
+        delta_lambda = lam_angstrom * np.log(10.0) * delta_log
+        if delta_lambda <= 0:
+            continue
+        return lam_angstrom / delta_lambda
+    return None
+
+
+def _close_all(hdul_list: Iterable[fits.HDUList]) -> None:
+    for hdul in hdul_list:
+        with suppress(Exception):  # pragma: no cover - defensive close
+            hdul.close()
+
+
+def _load_spectrum(**kwargs: Any) -> fits.HDUList:
+    if SDSS is None:
+        raise RuntimeError("astroquery.sdss is not available")
+    spectra = SDSS.get_spectra(**kwargs)
+    if not spectra:
+        raise LookupError("No spectra available for the requested target")
+    hdul = spectra[0]
+    # close any extra HDUs that may have been returned beyond the first
+    _close_all(spectra[1:])
+    return hdul
+
+
+def _query_specobj(**kwargs: Any) -> Table:
+    if SDSS is None:
+        raise RuntimeError("astroquery.sdss is not available")
+    table = SDSS.query_specobj(**kwargs)
+    if table is None or len(table) == 0:
+        raise LookupError("No SDSS metadata found for the requested target")
+    return table
+
+
+def _build_product(row: Any, *, hdul: fits.HDUList) -> Product:
+    specobjid = _to_str(_raw(row, "specobjid"))
+    if specobjid is None:
+        raise LookupError("SpecObjID missing from SDSS metadata")
+    wave_range = _extract_wave_range(hdul)
+    resolution = _estimate_resolution(hdul)
+    ra = _to_float(_raw(row, "ra"), unit=u.deg)
+    dec = _to_float(_raw(row, "dec"), unit=u.deg)
+    pipeline_version = _to_str(_raw(row, "run2d")) or _to_str(_raw(row, "run1d"))
+    urls = {
+        "portal": f"https://skyserver.sdss.org/dr17/en/tools/explore/summary.aspx?id={specobjid}",
+        "download": f"https://dr17.sdss.org/api/spectrum?specobjid={specobjid}",
+    }
+    extra: dict[str, Any] = {}
+    field_map = {
+        "plate": "plate",
+        "mjd": "mjd",
+        "fiberid": "fiberid",
+        "fiberID": "fiberid",
+        "programname": "programname",
+        "survey": "survey",
+        "instrument": "instrument",
+        "class": "class",
+        "z": "z",
+    }
+    for source_key, target_key in field_map.items():
+        if target_key in extra:
+            continue
+        value = _raw(row, source_key)
+        if value is None:
+            continue
+        if target_key in {"plate", "mjd", "fiberid"}:
+            numeric_int = _to_int(value)
+            if numeric_int is not None:
+                extra[target_key] = numeric_int
+            continue
+        numeric_float = _to_float(value)
+        if numeric_float is not None and target_key == "z":
+            extra[target_key] = numeric_float
+            continue
+        coerced = _coerce_scalar(value)
+        if coerced is not None:
+            extra[target_key] = coerced
+
+    hdul.close()
+
+    return Product(
+        provider="SDSS",
+        product_id=specobjid,
+        title=f"SDSS spectrum {specobjid}",
+        target=_to_str(_raw(row, "class")),
+        ra=ra,
+        dec=dec,
+        wave_range_nm=wave_range,
+        resolution_R=resolution,
+        wavelength_standard="vacuum",
+        flux_units=_FLUX_UNITS,
+        pipeline_version=pipeline_version,
+        urls=urls,
+        citation="SDSS Collaboration",
+        doi=None,
+        extra=extra,
+    )
 
 
 def fetch_by_specobjid(specobjid: int) -> Product:
-    raise NotImplementedError("SDSS adapter pending future implementation")
+    """Fetch an SDSS spectrum by SpecObjID."""
+
+    table = _query_specobj(specobjid=specobjid)
+    row = table[0]
+    hdul = _load_spectrum(specobjid=specobjid)
+    return _build_product(row, hdul=hdul)
 
 
 def fetch_by_plate(plate: int, mjd: int, fiber: int) -> Product:
-    raise NotImplementedError("SDSS adapter pending future implementation")
+    """Fetch an SDSS spectrum by plate/MJD/fiber identifier."""
+
+    table = _query_specobj(plate=plate, mjd=mjd, fiberID=fiber)
+    row = table[0]
+    hdul = _load_spectrum(plate=plate, mjd=mjd, fiberID=fiber)
+    return _build_product(row, hdul=hdul)
+
+
+__all__ = ["fetch_by_specobjid", "fetch_by_plate"]

--- a/tests/test_fetchers_mast.py
+++ b/tests/test_fetchers_mast.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from astropy.table import Table
+
+from server.fetchers import mast
+
+
+class _FakeObservations:
+    last_query_args: dict[str, object] | None = None
+    last_product_request: object | None = None
+
+    @classmethod
+    def query_region(cls, coord, radius):  # type: ignore[override]
+        cls.last_query_args = {"coord": coord, "radius": radius}
+        table = Table()
+        table["obsid"] = [123, 999]
+        table["obs_id"] = ["OBS123", "OBS999"]
+        table["dataproduct_type"] = ["spectrum", "image"]
+        table["obs_title"] = ["Test spectrum", "Other"]
+        table["target_name"] = ["Target A", "Target B"]
+        table["s_ra"] = [10.0, 11.0]
+        table["s_dec"] = [20.0, 21.0]
+        table["em_min"] = [1.0e-7, 1.0e-7]
+        table["em_max"] = [2.0e-7, 2.0e-7]
+        table["s_resolution"] = [1200.0, 0.0]
+        table["obs_collection"] = ["HST", "HST"]
+        table["provenance_name"] = ["CALSPEC v1", "IMAGE"]
+        table["flux_units"] = ["erg/s/cm^2/Å", "erg/s/cm^2/Å"]
+        table["data_doi"] = ["10.17909/T9XX11", ""]
+        table["dataURL"] = [
+            "https://mast.stsci.edu/spectrum.fits",
+            "https://mast.stsci.edu/image.fits",
+        ]
+        table["jpegURL"] = [
+            "https://mast.stsci.edu/spectrum.jpg",
+            "https://mast.stsci.edu/image.jpg",
+        ]
+        table["instrument_name"] = ["STIS", "WFC3"]
+        table["filters"] = ["G140L", "F606W"]
+        table["proposal_id"] = ["12345", "54321"]
+        table["proposal_pi"] = ["Doe", "Roe"]
+        table["t_exptime"] = [1500.0, 400.0]
+        table["dataRights"] = ["PUBLIC", "PUBLIC"]
+        return table
+
+    @classmethod
+    def get_product_list(cls, obsid):  # type: ignore[override]
+        cls.last_product_request = obsid
+        table = Table()
+        table["dataproduct_type"] = ["spectrum", "spectrum"]
+        table["productType"] = ["SCIENCE", "PREVIEW"]
+        table["dataURI"] = [
+            "mast:HLSP/test/spectrum.fits",
+            "mast:HLSP/test/preview.jpg",
+        ]
+        table["description"] = ["Calibrated spectrum", "Preview"]
+        return table
+
+
+def test_mast_search_products(monkeypatch) -> None:
+    monkeypatch.setattr(mast, "Observations", _FakeObservations)
+
+    products = list(mast.search_products(ra=10.0, dec=20.0, radius_arcsec=5.0))
+
+    assert len(products) == 1
+    product = products[0]
+    assert product.provider == "MAST"
+    assert product.product_id == "123"
+    assert product.title == "Test spectrum"
+    assert product.target == "Target A"
+    assert product.ra == 10.0
+    assert product.dec == 20.0
+    assert product.wave_range_nm == (100.0, 200.0)
+    assert product.resolution_R == 1200.0
+    assert product.pipeline_version == "CALSPEC v1"
+    assert product.urls["product"] == "https://mast.stsci.edu/spectrum.fits"
+    assert product.urls["download"].startswith("https://mast.stsci.edu/api/v0.1/Download/file?uri=")
+    assert product.doi == "10.17909/T9XX11"
+    assert product.extra["filters"] == "G140L"
+    assert _FakeObservations.last_product_request == 123

--- a/tests/test_fetchers_sdss.py
+++ b/tests/test_fetchers_sdss.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+from astropy.io import fits
+from astropy.table import Table
+
+from server.fetchers import sdss
+
+
+def _make_spectrum() -> fits.HDUList:
+    loglam = np.array([3.0, 3.0001, 3.0002], dtype=float)
+    flux = np.array([1.0, 1.1, 0.9], dtype=float)
+    ivar = np.array([1.0, 1.0, 1.0], dtype=float)
+    data = np.empty(loglam.size, dtype=[("loglam", "f8"), ("flux", "f8"), ("ivar", "f8")])
+    data["loglam"] = loglam
+    data["flux"] = flux
+    data["ivar"] = ivar
+    table_hdu = fits.BinTableHDU(data=data, name="COADD")
+    primary = fits.PrimaryHDU()
+    return fits.HDUList([primary, table_hdu])
+
+
+class _FakeSDSS:
+    last_query_kwargs: dict[str, Any] | None = None
+    last_spectrum_kwargs: dict[str, Any] | None = None
+
+    @classmethod
+    def query_specobj(cls, **kwargs):  # type: ignore[override]
+        cls.last_query_kwargs = kwargs
+        table = Table()
+        table["specobjid"] = [1234567890]
+        table["plate"] = [2345]
+        table["mjd"] = [56789]
+        table["fiberid"] = [321]
+        table["ra"] = [150.0]
+        table["dec"] = [2.3]
+        table["class"] = ["STAR"]
+        table["run2d"] = ["v5_7_0"]
+        table["programname"] = ["legacy"]
+        table["survey"] = ["sdss"]
+        table["instrument"] = ["SDSS"]
+        table["z"] = [0.001]
+        return table
+
+    @classmethod
+    def get_spectra(cls, **kwargs):  # type: ignore[override]
+        cls.last_spectrum_kwargs = kwargs
+        return [_make_spectrum()]
+
+
+def test_sdss_fetch_by_specobjid(monkeypatch) -> None:
+    monkeypatch.setattr(sdss, "SDSS", _FakeSDSS)
+
+    product = sdss.fetch_by_specobjid(1234567890)
+
+    assert product.provider == "SDSS"
+    assert product.product_id == "1234567890"
+    assert product.wave_range_nm is not None
+    assert product.wave_range_nm[0] > 0
+    assert product.resolution_R is not None and product.resolution_R > 0
+    assert product.wavelength_standard == "vacuum"
+    assert product.urls["download"].endswith("specobjid=1234567890")
+    assert product.extra["plate"] == 2345
+    assert product.extra["fiberid"] == 321
+    assert _FakeSDSS.last_query_kwargs == {"specobjid": 1234567890}
+    assert _FakeSDSS.last_spectrum_kwargs == {"specobjid": 1234567890}
+
+
+def test_sdss_fetch_by_plate(monkeypatch) -> None:
+    monkeypatch.setattr(sdss, "SDSS", _FakeSDSS)
+
+    product = sdss.fetch_by_plate(plate=2345, mjd=56789, fiber=321)
+
+    assert product.product_id == "1234567890"
+    assert _FakeSDSS.last_query_kwargs == {"plate": 2345, "mjd": 56789, "fiberID": 321}
+    assert _FakeSDSS.last_spectrum_kwargs == {"plate": 2345, "mjd": 56789, "fiberID": 321}


### PR DESCRIPTION
## Summary
- replace the placeholder MAST adapter with an astroquery-backed search that normalises metadata and assembles download links
- implement SDSS fetch helpers that derive wavelength coverage/resolution from spectra and expose canonical metadata
- add offline pytest coverage, refresh atlas documentation, and record the run in brains/patch notes/handoff while bumping to 1.0.0.dev12

## Testing
- `python -m pip install -e .`
- `ruff check .`
- `black --check .`
- `mypy .`
- `PYTHONPATH=. pytest -q`
- `python tools/verifiers/Verify-Atlas.py`
- `python tools/verifiers/Verify-PatchNotes.py`
- `python tools/verifiers/Verify-Handoff.py`
- `python tools/verifiers/Verify-Brains.py`
- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`


------
https://chatgpt.com/codex/tasks/task_e_68d55fc6c00083299b88702de55bc4b6