### PR TITLE
Surface archive product fallback link

### DIFF
--- a/app/ui/star_hub.py
+++ b/app/ui/star_hub.py
@@ -70,10 +70,20 @@ def _render_product_card(session: AppSessionState, product: Product, *, key_pref
                 st.markdown(
                     f"[Portal link]({product.urls['portal']})", help="Open the archive summary"
                 )
-            if product.urls.get("download"):
+            download_url = product.urls.get("download")
+            product_url = product.urls.get("product")
+            if download_url:
                 st.markdown(
-                    f"[Download link]({product.urls['download']})",
+                    f"[Download link]({download_url})",
                     help="Direct archive download",
+                )
+            elif product_url:
+                st.markdown(
+                    f"[Archive product page (may require archive landing page)]({product_url})",
+                    help=(
+                        "Opens the archive product page; it may redirect to a "
+                        "landing page before the download starts."
+                    ),
                 )
         with cols[1]:
             if st.button("Add to overlay", key=f"{key_prefix}_add"):

--- a/tests/test_fetcher_ingest.py
+++ b/tests/test_fetcher_ingest.py
@@ -21,6 +21,7 @@ def _fake_product() -> Product:
         pipeline_version="v1.2.3",
         urls={
             "download": "https://example.com/spectrum.fits",
+            "product": "https://example.com/spectrum",
             "portal": "https://example.com/portal",
         },
         citation="Example Collaboration",
@@ -58,3 +59,18 @@ def test_ingest_product_without_download_url() -> None:
         assert "download URL" in str(exc)
     else:  # pragma: no cover - should not happen
         raise AssertionError("Expected ProductIngestError for missing download URL")
+
+
+def test_ingest_product_falls_back_to_product_url() -> None:
+    product = _fake_product()
+    product.urls.pop("download")
+
+    fetched: list[str] = []
+
+    def fake_fetch(url: str) -> bytes:
+        fetched.append(url)
+        return Path("data/examples/example_spectrum.fits").read_bytes()
+
+    ingest_product(product, fetcher=fake_fetch)
+
+    assert fetched == [product.urls["product"]]


### PR DESCRIPTION
## Summary
- add an archive product fallback link in the Star Hub when a direct download is unavailable
- document the fallback behaviour in ingest product tests and ensure product URLs are preserved

## Testing
- PYTHONPATH=. pytest tests/test_fetcher_ingest.py

------
https://chatgpt.com/codex/tasks/task_e_68d5c33c2640832998f94fb6140065bd