### PR TITLE
Add SDSS search UI with class filter support

### DIFF
--- a/tests/test_fetchers_sdss.py
+++ b/tests/test_fetchers_sdss.py
@@ -24,25 +24,46 @@ def _make_spectrum() -> fits.HDUList:
 
 class _FakeSDSS:
     last_query_kwargs: dict[str, Any] | None = None
+    last_query_sql: str | None = None
+    last_query_sql_kwargs: dict[str, Any] | None = None
     last_spectrum_kwargs: dict[str, Any] | None = None
 
     @classmethod
-    def query_specobj(cls, **kwargs):  # type: ignore[override]
-        cls.last_query_kwargs = kwargs
+    def reset(cls) -> None:
+        cls.last_query_kwargs = None
+        cls.last_query_sql = None
+        cls.last_query_sql_kwargs = None
+        cls.last_spectrum_kwargs = None
+
+    @staticmethod
+    def _metadata_table() -> Table:
         table = Table()
         table["specobjid"] = [1234567890]
         table["plate"] = [2345]
         table["mjd"] = [56789]
         table["fiberid"] = [321]
+        table["fiberID"] = [321]
         table["ra"] = [150.0]
         table["dec"] = [2.3]
         table["class"] = ["STAR"]
         table["run2d"] = ["v5_7_0"]
+        table["run1d"] = ["v5_7_0"]
         table["programname"] = ["legacy"]
         table["survey"] = ["sdss"]
         table["instrument"] = ["SDSS"]
         table["z"] = [0.001]
         return table
+
+    @classmethod
+    def query_specobj(cls, **kwargs):  # type: ignore[override]
+        cls.last_query_kwargs = kwargs
+        return cls._metadata_table()
+
+    @classmethod
+    def query_sql(cls, sql_query: str, **kwargs):  # type: ignore[override]
+        cls.last_query_sql = sql_query
+        cls.last_query_sql_kwargs = kwargs
+        return cls._metadata_table()
 
     @classmethod
     def get_spectra(cls, **kwargs):  # type: ignore[override]
@@ -52,6 +73,7 @@ class _FakeSDSS:
 
 def test_sdss_fetch_by_specobjid(monkeypatch) -> None:
     monkeypatch.setattr(sdss, "SDSS", _FakeSDSS)
+    _FakeSDSS.reset()
 
     product = sdss.fetch_by_specobjid(1234567890)
 
@@ -70,9 +92,31 @@ def test_sdss_fetch_by_specobjid(monkeypatch) -> None:
 
 def test_sdss_fetch_by_plate(monkeypatch) -> None:
     monkeypatch.setattr(sdss, "SDSS", _FakeSDSS)
+    _FakeSDSS.reset()
 
     product = sdss.fetch_by_plate(plate=2345, mjd=56789, fiber=321)
 
     assert product.product_id == "1234567890"
     assert _FakeSDSS.last_query_kwargs == {"plate": 2345, "mjd": 56789, "fiberID": 321}
     assert _FakeSDSS.last_spectrum_kwargs == {"plate": 2345, "mjd": 56789, "fiberID": 321}
+
+
+def test_sdss_search_spectra_class_filter(monkeypatch) -> None:
+    monkeypatch.setattr(sdss, "SDSS", _FakeSDSS)
+    _FakeSDSS.reset()
+
+    products = list(
+        sdss.search_spectra(
+            ra=150.0,
+            dec=2.3,
+            radius_arcsec=45.0,
+            limit=5,
+            class_="STAR",
+        )
+    )
+
+    assert products
+    assert _FakeSDSS.last_query_sql is not None
+    assert "TOP 5" in _FakeSDSS.last_query_sql
+    assert "class IN ('STAR')" in _FakeSDSS.last_query_sql
+    assert _FakeSDSS.last_spectrum_kwargs == {"specobjid": 1234567890}


### PR DESCRIPTION
## Summary
- add an SDSS cone-search helper that issues SQL queries and normalises class filters before forwarding them to astroquery
- extend the Star Hub SDSS section with a coordinate-based search UI that passes the class_ keyword expected by the fetcher
- update the SDSS fetcher tests to exercise the new search behaviour and ensure the correct keyword is propagated

## Testing
- PYTHONPATH=. pytest tests/test_fetchers_sdss.py


------
https://chatgpt.com/codex/tasks/task_e_68d5c74bf2c08329b9c572361aade90a