### PR TITLE
Harden archive metadata merging and refactor SDSS search helpers

### DIFF
--- a/PATCH_NOTES/PATCH_NOTES_v1.0.0(n).md
+++ b/PATCH_NOTES/PATCH_NOTES_v1.0.0(n).md
@@ -1,0 +1,30 @@
+# Spectra App v1.0.0 (n) — Archive metadata resilience
+
+## Highlights
+- Hardened archive ingestion so spectra missing canonical metadata no longer crash the merge step.
+- Added regression coverage ensuring placeholder canonical spectra gain proper metadata during ingestion.
+- Advanced version metadata to `1.0.0n` / `1.0.0.dev14` for this stabilization patch.
+
+## Changes
+- Guarded `ingest_product` metadata merging to initialise a `TraceMetadata` stub when absent and to
+  tolerate missing source hashes when checking placeholder IDs.
+- Extended the ingestion test suite with coverage for metadata-free canonical spectra to prevent
+  regressions of the observed crash.
+- Bumped version identifiers in `pyproject.toml` and `app/config/version.json` to signal the fix.
+
+## Known Issues
+- Archive fetches still depend on network access; consider cached fixtures for offline validation.
+- Full citation/DOI propagation remains pending richer mission metadata cataloguing.
+- Export manifest replay work continues to track archive download URIs.
+
+## Verification
+- `python -m pip install -e .`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`

--- a/app/config/version.json
+++ b/app/config/version.json
@@ -1,4 +1,4 @@
 {
-  "app_version": "1.0.0m",
+  "app_version": "1.0.0n",
   "schema_version": 2
 }

--- a/brains/v1.0.0n__assistant__archive_metadata_resilience.md
+++ b/brains/v1.0.0n__assistant__archive_metadata_resilience.md
@@ -1,0 +1,48 @@
+# v1.0.0n — Archive metadata resilience
+
+## Context
+- Archive ingestion recently landed, but some fixtures and edge fetchers emit canonical spectra without
+  populated metadata objects.
+- `_merge_metadata` assumed a pre-existing `TraceMetadata`, causing crashes when a spectrum lacked that
+  attribute during Star Hub downloads.
+
+## Changes
+- Added a guard that initialises `TraceMetadata` on-demand before merging archive annotations.
+- Relaxed placeholder ID logic to handle spectra without a `source_hash` attribute gracefully.
+- Added regression coverage exercising `_merge_metadata` with a metadata-free stub spectrum.
+
+## Decisions
+- Preferred generating a fresh `TraceMetadata` rather than raising errors so archive ingestion remains
+  resilient to stub spectra.
+- Kept existing field precedence rules (only fill blanks) to avoid clobbering authoritative FITS header
+  values even when metadata is synthesised.
+- Used targeted helper functions to keep `_merge_metadata` maintainable while satisfying lint
+  constraints.
+
+## Tests & Evidence
+- `PYTHONPATH=. pytest -q`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`
+
+## Regressions Prevented
+- Stops archive ingestion from crashing when metadata is missing, keeping Star Hub usable for stubbed
+  or minimal spectra.
+- Maintains provenance and dedupe ledger behaviour by ensuring metadata containers always exist before
+  merging.
+
+## Follow-ups
+- Catalogue citation/DOI fields across archives so ingestion can enrich metadata further.
+- Investigate normalising ingestion helpers to always set `source_hash` for consistency.
+- Revisit export manifest wiring to include archive download URIs now that ingestion is resilient.
+
+## Checklist
+- [x] Patch notes added (`PATCH_NOTES/PATCH_NOTES_v1.0.0(n).md`)
+- [x] Handoff updated (`handoffs/HANDOFF_v1.0.0(n).md`)
+- [x] Version bumped (`pyproject.toml`, `app/config/version.json`)
+- [x] Tests added (`tests/test_fetcher_ingest.py`)

--- a/handoffs/HANDOFF_v1.0.0(n).md
+++ b/handoffs/HANDOFF_v1.0.0(n).md
@@ -1,0 +1,39 @@
+# HANDOFF 1.0.0n — Archive metadata resilience
+
+## 1) Summary of This Run
+- Hardened archive product ingestion so spectra without pre-populated canonical metadata no longer crash
+  when merging archive annotations.
+- Added regression coverage around the metadata merge guard and bumped version metadata to `1.0.0n` /
+  `1.0.0.dev14`.
+
+## 2) Current State of the Project
+- **Working tabs:** Overlay, Differential, Star Hub, Docs.
+- **Data ingestion:** ASCII/FITS loaders canonicalise to vacuum nm with provenance; archive downloads feed
+  through `ingest_product` with resilient metadata merging.
+- **Fetchers:** SIMBAD resolver, MAST region search, SDSS helpers, archive ingestion utility.
+- **Docs & comms:** Patch notes / brains / version metadata updated for this resilience fix.
+
+## 3) Next Steps (Prioritized)
+1. Capture archive-specific citation/DOI metadata where available and surface it in exports.
+2. Investigate caching or retry strategies for large archive downloads to keep the UI responsive.
+3. Extend export manifests to embed archive download URIs for deterministic replay.
+
+## 4) Decisions & Rationale
+- When metadata is missing on the canonical spectrum, initialise an empty `TraceMetadata` so archive
+  details can be merged without losing provenance expectations.
+- Treat absent `source_hash` values as a non-blocking case when replacing placeholder product IDs.
+- Codified the guard with a regression test to keep ingestion robust as fetchers evolve.
+
+## 5) References
+- Patch notes: `PATCH_NOTES/PATCH_NOTES_v1.0.0(n).md`
+- Brains log: `brains/v1.0.0n__assistant__archive_metadata_resilience.md`
+- Atlas: `atlas/fetchers_overview.md`
+
+## 6) Quick Start for the Next AI
+- Install deps / smoke: `python -m pip install -e .`, `PYTHONPATH=. pytest -q`.
+- Static checks: `ruff check .`, `black --check .`, `mypy .`.
+- Verifiers: `python tools/verifiers/Verify-Atlas.py`, `Verify-PatchNotes.py`, `Verify-Brains.py`,
+  `Verify-Handoff.py`, `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`.
+- Manual QA: Resolve a target via SIMBAD, fetch an archive spectrum, ingest it, and confirm provenance +
+  metadata render correctly in the overlay. Export the session to ensure archive ingests participate in
+  the manifest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "spectra-app"
-version = "1.0.0.dev13"
+version = "1.0.0.dev14"
 
 description = "Research-grade spectral comparison toolkit"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- ensure archive ingestion initialises missing `TraceMetadata` stubs before merging product details
- add regression coverage for metadata-free spectra and refactor SDSS search helpers to satisfy linting
- bump the app version to 1.0.0n / 1.0.0.dev14 and update continuity docs

## Testing
- ruff check .
- black --check .
- mypy .
- PYTHONPATH=. pytest -q
- python tools/verifiers/Verify-Atlas.py
- python tools/verifiers/Verify-PatchNotes.py
- python tools/verifiers/Verify-Brains.py
- python tools/verifiers/Verify-Handoff.py
- PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py

------
https://chatgpt.com/codex/tasks/task_e_68d5d1c50ff08329b9a6230d95aa8f55