### PR TITLE
Add NIST ASD line fetcher, ingestion, and UI

### DIFF
--- a/data/examples/nist_offline.json
+++ b/data/examples/nist_offline.json
@@ -1,0 +1,43 @@
+{
+  "entries": [
+    {
+      "species": "Fe I",
+      "wavelength_nm": 516.751,
+      "relative_intensity": 200.0,
+      "ritz_wavelength_nm": 516.751,
+      "observed_wavelength_nm": 516.742,
+      "transition": "a5D4 - z5F5",
+      "lower_level": "a5D4",
+      "upper_level": "z5F5",
+      "configuration": "3d6(5D)4s - 3d6(5D)4p",
+      "Aki": 1.2e7,
+      "notes": "Offline sample"
+    },
+    {
+      "species": "Fe I",
+      "wavelength_nm": 517.02,
+      "relative_intensity": 150.0,
+      "ritz_wavelength_nm": 517.02,
+      "observed_wavelength_nm": 517.01,
+      "transition": "a5D3 - z5F4",
+      "lower_level": "a5D3",
+      "upper_level": "z5F4",
+      "configuration": "3d6(5D)4s - 3d6(5D)4p",
+      "Aki": 9.1e6,
+      "notes": "Offline sample"
+    },
+    {
+      "species": "Mg II",
+      "wavelength_nm": 279.553,
+      "relative_intensity": 300.0,
+      "ritz_wavelength_nm": 279.553,
+      "observed_wavelength_nm": 279.552,
+      "transition": "3p 2P3/2 - 3d 2D5/2",
+      "lower_level": "3p 2P3/2",
+      "upper_level": "3d 2D5/2",
+      "configuration": "[Ne]3s",
+      "Aki": 2.6e8,
+      "notes": "Offline sample"
+    }
+  ]
+}

--- a/server/fetchers/nist.py
+++ b/server/fetchers/nist.py
@@ -1,0 +1,484 @@
+"""NIST Atomic Spectra Database integration utilities."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterable
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency in CI
+    from astroquery.nist import Nist as _AstroqueryNist
+except Exception:  # pragma: no cover - astroquery is optional for tests
+    _AstroqueryNist = None  # type: ignore[assignment]
+
+_CACHE_VERSION = 1
+_DEFAULT_CACHE_DIR = Path(__file__).resolve().parents[2] / "data" / "cache" / "nist"
+_DEFAULT_OFFLINE_PATH = (
+    Path(__file__).resolve().parents[2] / "data" / "examples" / "nist_offline.json"
+)
+
+
+class NistUnavailableError(RuntimeError):
+    """Raised when the NIST service cannot be reached and no cache is available."""
+
+
+@dataclass(slots=True)
+class _NormalisedRow:
+    wavelength_nm: float
+    relative_intensity: float
+    ritz_wavelength_nm: float | None = None
+    observed_wavelength_nm: float | None = None
+    transition: str | None = None
+    lower_level: str | None = None
+    upper_level: str | None = None
+    configuration: str | None = None
+    Aki: float | None = None
+    notes: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "wavelength_nm": self.wavelength_nm,
+            "relative_intensity": self.relative_intensity,
+            "ritz_wavelength_nm": self.ritz_wavelength_nm,
+            "observed_wavelength_nm": self.observed_wavelength_nm,
+            "transition": self.transition,
+            "lower_level": self.lower_level,
+            "upper_level": self.upper_level,
+            "configuration": self.configuration,
+            "Aki": self.Aki,
+            "notes": self.notes,
+        }
+
+
+def _slugify(value: str) -> str:
+    cleaned = "".join(char if char.isalnum() else "-" for char in value.lower())
+    return "-".join(part for part in cleaned.split("-") if part) or "species"
+
+
+def _angstrom_to_nm(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return float(value) / 10.0
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if math.isnan(float(value)):
+            return None
+        return float(value)
+    if isinstance(value, np.ndarray):  # pragma: no cover - defensive
+        if value.size == 0:
+            return None
+        return _coerce_float(value.item())
+    try:
+        text = str(value).strip()
+    except Exception:  # pragma: no cover - defensive
+        return None
+    if not text:
+        return None
+    try:
+        number = float(text)
+    except ValueError:
+        return None
+    if math.isnan(number):
+        return None
+    return number
+
+
+def _coerce_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, bytes):
+        value = value.decode("utf-8", errors="ignore")
+    text = str(value).strip()
+    return text or None
+
+
+def _table_value(table: Any, row: Any, candidates: Iterable[str]) -> Any:
+    colnames = getattr(table, "colnames", [])
+    for candidate in candidates:
+        if candidate in colnames:
+            try:
+                value = row[candidate]
+            except Exception:  # pragma: no cover - defensive access
+                continue
+            if getattr(value, "mask", False) is True:
+                continue
+            coerced = getattr(value, "filled", lambda: value)()
+            if coerced is np.ma.masked:  # type: ignore[attr-defined]
+                continue
+            return coerced
+    return None
+
+
+def _normalise_row(table: Any, row: Any) -> _NormalisedRow | None:
+    observed_angstrom = _coerce_float(
+        _table_value(
+            table,
+            row,
+            (
+                "Observed Wavelength",
+                "obs_wl_vac_(A)",
+                "obs_wl_air_(A)",
+                "Observed",
+            ),
+        )
+    )
+    ritz_angstrom = _coerce_float(
+        _table_value(
+            table,
+            row,
+            (
+                "Ritz",
+                "Ritz Wavelength",
+                "ritz_wl_vac_(A)",
+                "ritz_wl_air_(A)",
+            ),
+        )
+    )
+    rel_intensity = _coerce_float(
+        _table_value(
+            table,
+            row,
+            (
+                "Rel. Int.",
+                "RI",
+                "Intensity",
+                "Rel_Intensity",
+            ),
+        )
+    )
+    wavelength_angstrom = ritz_angstrom or observed_angstrom
+    if wavelength_angstrom is None:
+        return None
+    if rel_intensity is None:
+        rel_intensity = 0.0
+
+    transition = _coerce_str(
+        _table_value(
+            table,
+            row,
+            (
+                "Transition",
+                "Transition Ref.",
+                "Transition Reference",
+                "TransitionRef",
+            ),
+        )
+    )
+    lower = _coerce_str(
+        _table_value(
+            table,
+            row,
+            (
+                "Lower level",
+                "Lower Level",
+                "Lower Level (J)",
+                "Lower level (cm-1)",
+                "Lower",
+            ),
+        )
+    )
+    upper = _coerce_str(
+        _table_value(
+            table,
+            row,
+            (
+                "Upper level",
+                "Upper Level",
+                "Upper Level (J)",
+                "Upper",
+            ),
+        )
+    )
+    configuration = _coerce_str(
+        _table_value(
+            table,
+            row,
+            (
+                "Configuration",
+                "Electron Configuration",
+                "Config.",
+            ),
+        )
+    )
+    Aki = _coerce_float(
+        _table_value(
+            table,
+            row,
+            (
+                "Aki",
+                "Aki (s-1)",
+                "Aki (s^-1)",
+                "A_{ki}",
+            ),
+        )
+    )
+    notes = _coerce_str(
+        _table_value(
+            table,
+            row,
+            (
+                "Notes",
+                "Line Ref.",
+                "Comment",
+            ),
+        )
+    )
+
+    return _NormalisedRow(
+        wavelength_nm=float(_angstrom_to_nm(wavelength_angstrom)),
+        relative_intensity=float(rel_intensity),
+        ritz_wavelength_nm=_angstrom_to_nm(ritz_angstrom),
+        observed_wavelength_nm=_angstrom_to_nm(observed_angstrom),
+        transition=transition,
+        lower_level=lower,
+        upper_level=upper,
+        configuration=configuration,
+        Aki=Aki,
+        notes=notes,
+    )
+
+
+def _table_to_rows(table: Any) -> list[dict[str, Any]]:
+    rows: list[_NormalisedRow] = []
+    for entry in table:
+        normalised = _normalise_row(table, entry)
+        if normalised is None:
+            continue
+        rows.append(normalised)
+    rows.sort(key=lambda item: item.wavelength_nm)
+    return [row.to_dict() for row in rows]
+
+
+def _remote_fetch(
+    species: str,
+    wavelength_min_nm: float,
+    wavelength_max_nm: float,
+    *,
+    use_ritz_wavelength: bool,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    if _AstroqueryNist is None:
+        raise RuntimeError("astroquery.nist is not available")
+    range_angstrom = f"{wavelength_min_nm * 10:.3f}-{wavelength_max_nm * 10:.3f}"
+    try:
+        table = _AstroqueryNist.query(
+            wavelength_range=range_angstrom,
+            spectrum=species,
+            wavelength_type="vacuum" if use_ritz_wavelength else "air",
+            linelist="Atomic",
+        )
+    except Exception as exc:  # pragma: no cover - network failure path
+        raise RuntimeError("NIST query failed") from exc
+    if table is None:
+        return [], {"source": "nist_api", "query": range_angstrom}
+    rows = _table_to_rows(table)
+    return rows, {"source": "nist_api", "query": range_angstrom}
+
+
+def _load_offline_catalog(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text())
+    except Exception:  # pragma: no cover - malformed fixture
+        return []
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            wavelength = float(entry["wavelength_nm"])
+            intensity = float(entry.get("relative_intensity", 0.0))
+        except Exception:
+            continue
+        record = dict(entry)
+        record["wavelength_nm"] = wavelength
+        record["relative_intensity"] = intensity
+        result.append(record)
+    result.sort(key=lambda item: item["wavelength_nm"])
+    return result
+
+
+def _offline_fallback(
+    species: str,
+    wavelength_min_nm: float,
+    wavelength_max_nm: float,
+    *,
+    offline_catalog: Path,
+) -> tuple[list[dict[str, Any]], dict[str, Any]] | None:
+    rows = _load_offline_catalog(offline_catalog)
+    if not rows:
+        return None
+    filtered = [
+        row
+        for row in rows
+        if row.get("species", "").lower() == species.lower()
+        and wavelength_min_nm <= float(row.get("wavelength_nm", 0.0)) <= wavelength_max_nm
+    ]
+    if not filtered:
+        return None
+    return filtered, {"source": "offline", "catalog": str(offline_catalog)}
+
+
+def _cache_filename(
+    species: str,
+    wavelength_min_nm: float,
+    wavelength_max_nm: float,
+    *,
+    use_ritz_wavelength: bool,
+) -> str:
+    slug = _slugify(species)
+    window = f"{wavelength_min_nm:.3f}-{wavelength_max_nm:.3f}"
+    mode = "ritz" if use_ritz_wavelength else "observed"
+    return f"{slug}_{window}_{mode}.json"
+
+
+def _read_cache(path: Path) -> tuple[list[dict[str, Any]], dict[str, Any]] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text())
+    except Exception:
+        return None
+    if payload.get("version") != _CACHE_VERSION:
+        return None
+    rows = payload.get("rows")
+    metadata = payload.get("metadata", {})
+    if not isinstance(rows, list):
+        return None
+    return rows, metadata
+
+
+def _write_cache(path: Path, rows: list[dict[str, Any]], metadata: dict[str, Any]) -> None:
+    payload = {
+        "version": _CACHE_VERSION,
+        "rows": rows,
+        "metadata": metadata,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2))
+
+
+def fetch_lines(
+    species: str,
+    wavelength_min_nm: float,
+    wavelength_max_nm: float,
+    *,
+    use_ritz_wavelength: bool = True,
+    cache_dir: Path | None = None,
+    offline_catalog: Path | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Fetch spectral line data from the NIST ASD, with caching and fallback."""
+
+    if wavelength_min_nm >= wavelength_max_nm:
+        raise ValueError("Minimum wavelength must be less than maximum wavelength")
+
+    cache_root = cache_dir or _DEFAULT_CACHE_DIR
+    offline_path = offline_catalog or _DEFAULT_OFFLINE_PATH
+    cache_file = cache_root / _cache_filename(
+        species,
+        wavelength_min_nm,
+        wavelength_max_nm,
+        use_ritz_wavelength=use_ritz_wavelength,
+    )
+
+    cached_rows: list[dict[str, Any]] | None = None
+    cached_metadata: dict[str, Any] | None = None
+    cached = _read_cache(cache_file)
+    if cached is not None:
+        cached_rows, cached_metadata = cached
+
+    try:
+        rows, remote_meta = _remote_fetch(
+            species,
+            wavelength_min_nm,
+            wavelength_max_nm,
+            use_ritz_wavelength=use_ritz_wavelength,
+        )
+        fetched_at = datetime.now(UTC).isoformat()
+        cache_metadata = {
+            "fetched_at": fetched_at,
+            "source": remote_meta.get("source", "nist_api"),
+            "offline_fallback": False,
+        }
+        _write_cache(cache_file, rows, cache_metadata)
+        metadata = {
+            "species": species,
+            "wavelength_window_nm": (wavelength_min_nm, wavelength_max_nm),
+            "use_ritz_wavelength": use_ritz_wavelength,
+            "cache_hit": False,
+            "fetched_at": fetched_at,
+            "row_count": len(rows),
+            "cache_path": str(cache_file),
+            "source": remote_meta.get("source", "nist_api"),
+            "query": remote_meta.get("query"),
+        }
+        return rows, metadata
+    except Exception as exc:
+        if cached_rows is not None and cached_metadata is not None:
+            metadata = {
+                "species": species,
+                "wavelength_window_nm": (wavelength_min_nm, wavelength_max_nm),
+                "use_ritz_wavelength": use_ritz_wavelength,
+                "cache_hit": True,
+                "fetched_at": cached_metadata.get("fetched_at"),
+                "cached_at": cached_metadata.get("fetched_at"),
+                "row_count": len(cached_rows),
+                "cache_path": str(cache_file),
+                "source": cached_metadata.get("source", "cache"),
+                "error": str(exc),
+            }
+            if cached_metadata.get("offline_fallback"):
+                metadata["offline_fallback"] = True
+            return cached_rows, metadata
+
+        offline = _offline_fallback(
+            species,
+            wavelength_min_nm,
+            wavelength_max_nm,
+            offline_catalog=offline_path,
+        )
+        if offline is not None:
+            rows, offline_meta = offline
+            fetched_at = datetime.now(UTC).isoformat()
+            metadata = {
+                "species": species,
+                "wavelength_window_nm": (wavelength_min_nm, wavelength_max_nm),
+                "use_ritz_wavelength": use_ritz_wavelength,
+                "cache_hit": False,
+                "offline_fallback": True,
+                "fetched_at": fetched_at,
+                "row_count": len(rows),
+                "source": offline_meta.get("source", "offline"),
+                "catalog": offline_meta.get("catalog"),
+                "error": str(exc),
+            }
+            try:
+                cache_metadata = {
+                    "fetched_at": fetched_at,
+                    "source": metadata["source"],
+                    "offline_fallback": True,
+                    "error": str(exc),
+                }
+                _write_cache(cache_file, rows, cache_metadata)
+                metadata["cache_path"] = str(cache_file)
+            except Exception:  # pragma: no cover - cache write best effort
+                pass
+            return rows, metadata
+        raise NistUnavailableError(
+            "NIST ASD service unavailable and no cached/offline data present"
+        ) from exc
+
+
+__all__ = ["NistUnavailableError", "fetch_lines"]

--- a/server/ingest/nist_lines.py
+++ b/server/ingest/nist_lines.py
@@ -1,0 +1,146 @@
+"""Convert NIST ASD line results into canonical spectra."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any, Iterable, cast
+
+import numpy as np
+
+from server.models import CanonicalSpectrum, ProvenanceEvent, TraceMetadata, ValueMode
+
+
+def _prepare_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
+    prepared: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        wavelength = row.get("wavelength_nm")
+        intensity = row.get("relative_intensity")
+        if wavelength is None or intensity is None:
+            continue
+        try:
+            numeric_wavelength = float(wavelength)
+            numeric_intensity = float(intensity)
+        except Exception:
+            continue
+        prepared.append({**row, "wavelength_nm": numeric_wavelength, "relative_intensity": numeric_intensity})
+    prepared.sort(key=lambda item: item["wavelength_nm"])
+    return prepared
+
+
+def _event_timestamp(metadata: dict[str, Any]) -> datetime:
+    raw = metadata.get("fetched_at") or metadata.get("cached_at")
+    if isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            pass
+    return datetime.now(UTC)
+
+
+def _label(species: str, window: tuple[float, float] | None) -> str:
+    if window is None:
+        return f"NIST lines: {species}"
+    low, high = window
+    return f"NIST lines: {species} {low:.1f}–{high:.1f} nm"
+
+
+def _compute_hash(rows: list[dict[str, Any]], species: str, window: tuple[float, float] | None) -> str:
+    payload = {
+        "species": species,
+        "window": window,
+        "rows": rows,
+    }
+    digest = hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+    return digest
+
+
+def to_canonical(
+    rows: Iterable[dict[str, Any]],
+    metadata: dict[str, Any],
+    *,
+    app_version: str,
+) -> CanonicalSpectrum:
+    """Convert raw NIST rows and metadata into a :class:`CanonicalSpectrum`."""
+
+    species = str(metadata.get("species") or "Unknown species")
+    window_raw = metadata.get("wavelength_window_nm")
+    window: tuple[float, float] | None = None
+    if isinstance(window_raw, (list, tuple)) and len(window_raw) == 2:
+        try:
+            window = (float(window_raw[0]), float(window_raw[1]))
+        except Exception:
+            window = None
+
+    prepared = _prepare_rows(rows)
+    if not prepared:
+        raise ValueError("No valid NIST lines were provided")
+
+    wavelengths = np.array([row["wavelength_nm"] for row in prepared], dtype=float)
+    intensities = np.array([row["relative_intensity"] for row in prepared], dtype=float)
+    preferred = bool(metadata.get("use_ritz_wavelength", True))
+
+    label = _label(species, window)
+    trace_metadata = TraceMetadata(
+        provider="NIST ASD",
+        title=label,
+        target=species,
+        flux_units=None,
+        extra={
+            "nist": {
+                "species": species,
+                "wavelength_window_nm": window,
+                "use_ritz_wavelength": preferred,
+                "cache_hit": bool(metadata.get("cache_hit", False)),
+                "offline_fallback": bool(metadata.get("offline_fallback", False)),
+                "fetched_at": metadata.get("fetched_at"),
+                "cached_at": metadata.get("cached_at"),
+                "source": metadata.get("source"),
+                "query": metadata.get("query"),
+                "catalog": metadata.get("catalog"),
+                "row_count": len(prepared),
+                "rows": prepared,
+            }
+        },
+    )
+
+    provenance = [
+        ProvenanceEvent(
+            step="fetch_nist_lines",
+            parameters={
+                "species": species,
+                "wavelength_window_nm": window,
+                "use_ritz_wavelength": preferred,
+                "cache_hit": bool(metadata.get("cache_hit", False)),
+                "offline_fallback": bool(metadata.get("offline_fallback", False)),
+                "row_count": len(prepared),
+                "fetched_at": metadata.get("fetched_at"),
+                "cached_at": metadata.get("cached_at"),
+                "source": metadata.get("source"),
+                "query": metadata.get("query"),
+                "catalog": metadata.get("catalog"),
+                "app_version": app_version,
+            },
+            timestamp=_event_timestamp(metadata),
+        )
+    ]
+
+    source_hash = _compute_hash(prepared, species, window)
+
+    return CanonicalSpectrum(
+        label=label,
+        wavelength_vac_nm=wavelengths,
+        values=intensities,
+        value_mode=cast(ValueMode, "relative_intensity"),
+        value_unit=None,
+        metadata=trace_metadata,
+        provenance=provenance,
+        source_hash=source_hash,
+        uncertainties=None,
+    )
+
+
+__all__ = ["to_canonical"]

--- a/tests/test_fetchers_nist.py
+++ b/tests/test_fetchers_nist.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import pytest
+
+from server.fetchers import nist
+
+
+_SAMPLE_ROWS = [
+    {
+        "wavelength_nm": 500.0,
+        "relative_intensity": 120.0,
+        "ritz_wavelength_nm": 500.0,
+        "observed_wavelength_nm": 500.0,
+        "transition": "a - b",
+    }
+]
+
+
+def test_fetch_lines_writes_and_reads_cache(tmp_path, monkeypatch) -> None:
+    cache_dir = tmp_path / "cache"
+
+    def fake_remote(species, wmin, wmax, *, use_ritz_wavelength):
+        assert species == "Fe I"
+        assert wmin == pytest.approx(500.0)
+        assert wmax == pytest.approx(501.0)
+        assert use_ritz_wavelength is True
+        return list(_SAMPLE_ROWS), {"source": "test", "query": "5000-5010"}
+
+    monkeypatch.setattr(nist, "_remote_fetch", fake_remote)
+
+    rows, metadata = nist.fetch_lines(
+        "Fe I", 500.0, 501.0, cache_dir=cache_dir, use_ritz_wavelength=True
+    )
+    assert rows == _SAMPLE_ROWS
+    assert metadata["cache_hit"] is False
+    cache_files = list(cache_dir.rglob("*.json"))
+    assert len(cache_files) == 1
+
+    def failing_remote(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(nist, "_remote_fetch", failing_remote)
+
+    rows_cached, metadata_cached = nist.fetch_lines(
+        "Fe I", 500.0, 501.0, cache_dir=cache_dir, use_ritz_wavelength=True
+    )
+    assert rows_cached == _SAMPLE_ROWS
+    assert metadata_cached["cache_hit"] is True
+    assert "boom" in metadata_cached["error"]
+
+
+def test_fetch_lines_offline_fallback(tmp_path, monkeypatch) -> None:
+    offline_catalog = tmp_path / "offline.json"
+    offline_payload = {
+        "entries": [
+            {
+                "species": "Fe I",
+                "wavelength_nm": 500.5,
+                "relative_intensity": 80.0,
+            }
+        ]
+    }
+    offline_catalog.write_text(json.dumps(offline_payload))
+
+    def failing_remote(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(nist, "_remote_fetch", failing_remote)
+
+    rows, metadata = nist.fetch_lines(
+        "Fe I",
+        500.0,
+        501.0,
+        cache_dir=tmp_path / "cache",
+        offline_catalog=offline_catalog,
+    )
+    assert rows[0]["wavelength_nm"] == pytest.approx(500.5)
+    assert metadata["offline_fallback"] is True
+    assert metadata["cache_hit"] is False
+    assert "network down" in metadata["error"]
+
+
+def test_fetch_lines_raises_without_fallback(tmp_path, monkeypatch) -> None:
+    def failing_remote(*args, **kwargs):
+        raise RuntimeError("no service")
+
+    monkeypatch.setattr(nist, "_remote_fetch", failing_remote)
+
+    cache_dir = tmp_path / "cache"
+    with pytest.raises(nist.NistUnavailableError):
+        nist.fetch_lines(
+            "Fe I",
+            500.0,
+            501.0,
+            cache_dir=cache_dir,
+            offline_catalog=tmp_path / "missing.json",
+        )

--- a/tests/test_ingest_nist.py
+++ b/tests/test_ingest_nist.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import numpy as np
+
+from server.ingest.nist_lines import to_canonical
+
+
+def test_to_canonical_metadata_and_provenance() -> None:
+    rows = [
+        {
+            "wavelength_nm": 500.0,
+            "relative_intensity": 120.0,
+            "ritz_wavelength_nm": 500.0,
+            "transition": "a - b",
+        },
+        {
+            "wavelength_nm": 501.0,
+            "relative_intensity": 80.0,
+            "ritz_wavelength_nm": 501.0,
+            "transition": "b - c",
+        },
+    ]
+    metadata = {
+        "species": "Fe I",
+        "wavelength_window_nm": (499.5, 501.5),
+        "use_ritz_wavelength": True,
+        "cache_hit": True,
+        "offline_fallback": False,
+        "fetched_at": "2024-01-01T00:00:00+00:00",
+        "source": "cache",
+    }
+
+    canonical = to_canonical(rows, metadata, app_version="1.2.3")
+
+    assert canonical.label.startswith("NIST lines: Fe I")
+    assert canonical.value_mode == "relative_intensity"
+    assert canonical.metadata.provider == "NIST ASD"
+    extra = canonical.metadata.extra["nist"]
+    assert extra["cache_hit"] is True
+    assert extra["row_count"] == 2
+    assert extra["rows"][0]["transition"] == "a - b"
+    event = canonical.provenance[0]
+    assert event.step == "fetch_nist_lines"
+    assert event.parameters["species"] == "Fe I"
+    assert event.parameters["app_version"] == "1.2.3"
+    assert event.parameters["cache_hit"] is True
+    assert np.allclose(canonical.wavelength_vac_nm, np.array([500.0, 501.0]))
+    assert np.allclose(canonical.values, np.array([120.0, 80.0]))
+
+
+def test_to_canonical_rejects_empty_rows() -> None:
+    try:
+        to_canonical([], {"species": "Fe I"}, app_version="1.0.0")
+    except ValueError as exc:
+        assert "No valid NIST lines" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("Expected ValueError for empty rows")

--- a/tests/test_ui_nist_sidebar.py
+++ b/tests/test_ui_nist_sidebar.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from streamlit.testing.v1 import AppTest
+
+from app.state.session import AppSessionState
+from app.ui import main as main_ui
+class _FakeCatalog:
+    def species(self) -> list[str]:
+        return ["Fe I", "Mg II"]
+
+
+def _render_sidebar_app(session, catalog, settings) -> None:
+    from app.ui import main as module_main
+
+    module_main._configure_sidebar(  # type: ignore[attr-defined]
+        session,
+        catalog,
+        settings,
+        app_version="9.9.9",
+    )
+
+
+def test_sidebar_form_registers_nist_trace(monkeypatch) -> None:
+    session = AppSessionState()
+    catalog = _FakeCatalog()
+
+    rows = [
+        {
+            "wavelength_nm": 500.0,
+            "relative_intensity": 100.0,
+            "ritz_wavelength_nm": 500.0,
+            "transition": "a - b",
+        }
+    ]
+    metadata = {
+        "species": "Fe I",
+        "wavelength_window_nm": (500.0, 501.0),
+        "use_ritz_wavelength": True,
+        "cache_hit": False,
+        "fetched_at": "2024-01-01T00:00:00+00:00",
+        "source": "test",
+    }
+
+    def fake_fetch(species, wmin, wmax, *, use_ritz_wavelength, **kwargs):
+        assert species == "Fe I"
+        assert wmin == 500.0
+        assert wmax == 501.0
+        assert use_ritz_wavelength is True
+        return rows, metadata
+
+    monkeypatch.setattr(main_ui, "fetch_lines", fake_fetch)
+
+    settings = {"line_overlays": {"default_species": "Fe I", "default_window_nm": [500.0, 501.0]}}
+
+    at = AppTest.from_function(
+        _render_sidebar_app, args=(session, catalog, settings)
+    ).run()
+    at.sidebar.button(key="nist_fetch_submit").click().run()
+
+    assert session.trace_order
+    trace = session.traces[session.trace_order[-1]]
+    assert trace.label.startswith("NIST lines: Fe I")
+    assert trace.metadata.extra["nist"]["source"] == "test"
+    assert trace.provenance[0].parameters["app_version"] == "9.9.9"
+    assert at.sidebar.success[0].value.startswith("Added NIST lines for Fe I")


### PR DESCRIPTION
## Summary
- implement a cached NIST ASD fetcher with offline fallback data and detailed query metadata
- convert fetched line results into canonical spectra including provenance with app version and cache/offline flags
- expose a Streamlit sidebar form for fetching/registering NIST line overlays and display cache/offline notices
- add fixture data and tests covering cache behavior, ingestion metadata, and the sidebar interaction

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5ef5a70388329a8c26c2c0fb9a905