### PR TITLE
Normalize Star Hub selection handling

### DIFF
--- a/PATCH_NOTES/PATCH_NOTES_v1.0.0(p).md
+++ b/PATCH_NOTES/PATCH_NOTES_v1.0.0(p).md
@@ -1,0 +1,29 @@
+# Spectra App v1.0.0 (p) — Provider federation
+
+## Highlights
+- Introduced a provider registry with deduplicated fan-out across MAST, SDSS, ESO, and DOI adapters.
+- Refreshed Star Hub to resolve once, persist filters, surface previews, and ingest multiple products in one action.
+- Added regression coverage for provider registration, ESO/DOI adapters, and the Streamlit flow that pulls selected spectra into overlays.
+
+## Changes
+- Added `server/providers/__init__.py` defining `ProviderQuery`, `ProviderHit`, registry helpers, and `search_all(...)` orchestration.
+- Updated MAST and SDSS adapters to emit `ProviderHit` records and wired new ESO/DOI sample adapters into the registry.
+- Reworked `server/fetchers/resolver_simbad.resolve` with an explicit fixture toggle and rewrote `app/ui/star_hub.py` around the provider registry and multi-select ingestion.
+- Documented the provider federation in `atlas/fetchers_overview.md` and refreshed the Star Hub summary in `docs/static/overview.md`.
+
+## Known Issues
+- ESO/DOI adapters ship curated samples rather than live archive queries; future runs can replace them with production clients.
+- Preview rendering relies on remote URLs; offline runs fall back to simple preview links when images cannot be fetched.
+- Registry fan-out currently swallows provider exceptions silently; we may want structured error reporting in a follow-up.
+
+## Verification
+- `python -m pip install -e .`
+- `ruff check .`
+- `black --check .`
+- `mypy .`
+- `PYTHONPATH=. pytest -q`
+- `python tools/verifiers/Verify-Atlas.py`
+- `python tools/verifiers/Verify-PatchNotes.py`
+- `python tools/verifiers/Verify-Brains.py`
+- `python tools/verifiers/Verify-Handoff.py`
+- `PYTHONPATH=. python tools/verifiers/Verify-UI-Contract.py`

--- a/app/ui/star_hub.py
+++ b/app/ui/star_hub.py
@@ -1,27 +1,35 @@
-"""Star Hub tab with resolver and archive integration."""
+"""Star Hub tab combining resolver and provider registry searches."""
 
 from __future__ import annotations
 
+from ast import literal_eval
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
 import streamlit as st
 
 from app.state.session import AppSessionState
-from server.fetchers import mast, resolver_simbad, sdss
+from server.fetchers import resolver_simbad
 from server.fetchers.ingest_product import ProductIngestError, ingest_product
-from server.fetchers.models import Product, ResolverResult
+from server.fetchers.models import ResolverResult
+from server.providers import ProviderHit, ProviderQuery, provider_names, search_all
 
 
 @dataclass(slots=True)
 class _StarHubState:
     resolver: ResolverResult | None = None
-    mast_products: list[Product] = field(default_factory=list)
-    sdss_products: list[Product] = field(default_factory=list)
-    sdss_search_results: list[Product] = field(default_factory=list)
+    hits: dict[str, ProviderHit] = field(default_factory=dict)
+    hit_order: list[str] = field(default_factory=list)
+    selection: list[str] = field(default_factory=list)
 
 
 _STATE_KEY = "star_hub_state"
+_FILTER_PROVIDERS_KEY = "star_hub_filter_providers"
+_FILTER_TELESCOPES_KEY = "star_hub_filter_telescopes"
+_FILTER_INSTRUMENTS_KEY = "star_hub_filter_instruments"
+_FILTER_WAVE_KEY = "star_hub_filter_wave"
+_SELECTION_KEY = "star_hub_selection"
 
 
 def _get_state() -> _StarHubState:
@@ -33,6 +41,43 @@ def _get_state() -> _StarHubState:
     return state
 
 
+def _hit_key(hit: ProviderHit) -> str:
+    product_id = hit.product.product_id or hit.product.title or "unknown"
+    return f"{hit.provider}:{product_id}"
+
+
+def _expand_string_entry(entry: str, hits: dict[str, ProviderHit]) -> list[str]:
+    if entry in hits:
+        return [entry]
+    if entry.startswith("[") and entry.endswith("]"):
+        try:
+            decoded = literal_eval(entry)
+        except (ValueError, SyntaxError):
+            return []
+        if isinstance(decoded, list):
+            return _expand_sequence_entry(decoded, hits)
+        return []
+    for key, hit in hits.items():
+        if _format_hit_label(hit) == entry:
+            return [key]
+    return []
+
+
+def _expand_sequence_entry(entry: Sequence[Any], hits: dict[str, ProviderHit]) -> list[str]:
+    keys: list[str] = []
+    for item in entry:
+        keys.extend(_expand_selection_entry(item, hits))
+    return keys
+
+
+def _expand_selection_entry(entry: Any, hits: dict[str, ProviderHit]) -> list[str]:
+    if isinstance(entry, str):
+        return _expand_string_entry(entry, hits)
+    if isinstance(entry, Sequence):
+        return _expand_sequence_entry(entry, hits)
+    return []
+
+
 def _format_wave_range(wave_range: tuple[float, float] | None) -> str:
     if not wave_range:
         return "—"
@@ -40,174 +85,193 @@ def _format_wave_range(wave_range: tuple[float, float] | None) -> str:
     return f"{start:.1f}–{end:.1f} nm"
 
 
-def _render_product_card(session: AppSessionState, product: Product, *, key_prefix: str) -> None:
+def _format_hit_label(hit: ProviderHit) -> str:
+    title = hit.product.title or hit.product.product_id or "Archive product"
+    parts = [hit.provider]
+    if hit.telescope:
+        parts.append(hit.telescope)
+    if hit.instrument:
+        parts.append(hit.instrument)
+    summary = ", ".join(parts)
+    return f"{title} ({summary})"
+
+
+def _store_hits(state: _StarHubState, hits: list[ProviderHit]) -> None:
+    mapping = {_hit_key(hit): hit for hit in hits}
+    state.hits = mapping
+    state.hit_order = list(mapping.keys())
+    current_selection = st.session_state.get(_SELECTION_KEY, [])
+    filtered_selection = [key for key in current_selection if key in state.hits]
+    st.session_state[_SELECTION_KEY] = filtered_selection
+    state.selection = filtered_selection
+
+
+def _hit_metadata_lines(product: ProviderHit) -> list[str]:
+    parts = [product.provider]
+    if product.telescope:
+        parts.append(product.telescope)
+    if product.instrument:
+        parts.append(product.instrument)
+    if product.wave_range_nm:
+        parts.append(_format_wave_range(product.wave_range_nm))
+    return parts
+
+
+def _render_hit_details(product: ProviderHit) -> None:
+    record = product.product
+    if record.target:
+        st.write(f"Target: {record.target}")
+    if record.pipeline_version:
+        st.write(f"Pipeline: {record.pipeline_version}")
+    if record.flux_units:
+        st.write(f"Flux units: {record.flux_units}")
+    portal = record.urls.get("portal")
+    if portal:
+        st.markdown(f"[Portal link]({portal})")
+    if product.download_url:
+        st.markdown(f"[Download link]({product.download_url})")
+    if record.doi:
+        st.write(f"DOI: {record.doi}")
+    if product.extras:
+        with st.expander("More details", expanded=False):
+            st.json(product.extras)
+
+
+def _render_hit_preview(hit: ProviderHit) -> None:
+    if not hit.preview_url:
+        return
+    try:
+        st.image(hit.preview_url, caption="Preview", use_column_width=True)
+    except Exception:
+        st.markdown(f"[Preview image]({hit.preview_url})")
+
+
+def _render_hit_card(hit: ProviderHit) -> None:
+    record = hit.product
+    title = record.title or record.product_id or "Archive product"
     with st.container():
-        title = product.title or product.product_id or "Archive product"
         st.markdown(f"**{title}**")
-        st.caption(
-            " | ".join(
-                filter(
-                    None,
-                    [
-                        product.provider,
-                        f"λ: {_format_wave_range(product.wave_range_nm)}",
-                        (
-                            f"R ≈ {product.resolution_R:.0f}"
-                            if product.resolution_R is not None
-                            else None
-                        ),
-                    ],
-                )
-            )
-        )
-        cols = st.columns([3, 1])
-        with cols[0]:
-            if product.target:
-                st.write(f"Target: {product.target}")
-            if product.pipeline_version:
-                st.write(f"Pipeline: {product.pipeline_version}")
-            if product.flux_units:
-                st.write(f"Flux units: {product.flux_units}")
-            if product.urls.get("portal"):
-                st.markdown(
-                    f"[Portal link]({product.urls['portal']})", help="Open the archive summary"
-                )
-            download_url = product.urls.get("download")
-            product_url = product.urls.get("product")
-            if download_url:
-                st.markdown(
-                    f"[Download link]({download_url})",
-                    help="Direct archive download",
-                )
-            elif product_url:
-                st.markdown(
-                    f"[Archive product page (may require archive landing page)]({product_url})",
-                    help=(
-                        "Opens the archive product page; it may redirect to a "
-                        "landing page before the download starts."
-                    ),
-                )
-        with cols[1]:
-            if st.button("Add to overlay", key=f"{key_prefix}_add"):
-                _ingest_product(session, product)
+        st.caption(" | ".join(_hit_metadata_lines(hit)))
+        details_col, preview_col = st.columns([3, 2])
+        with details_col:
+            _render_hit_details(hit)
+        with preview_col:
+            _render_hit_preview(hit)
 
 
-def _ingest_product(session: AppSessionState, product: Product) -> None:
-    with st.spinner("Downloading and ingesting product..."):
-        try:
-            canonical = ingest_product(product)
-        except ProductIngestError as exc:
-            st.error(str(exc))
-            return
-    added, trace_id = session.register_trace(canonical)
-    if added:
-        st.success(f"Added trace '{canonical.label}'")
-    else:
-        st.warning(f"Duplicate detected for '{canonical.label}' (trace {trace_id})")
-
-
-def _render_mast_section(session: AppSessionState, state: _StarHubState) -> None:
-    st.markdown("### MAST archive")
-    resolver = state.resolver
-    if resolver is None or resolver.ra is None or resolver.dec is None:
-        st.info("Resolve a target with coordinates to search MAST products.")
+def _sync_options(key: str, options: list[str]) -> None:
+    stored = st.session_state.get(key)
+    if not isinstance(stored, list):
+        st.session_state[key] = list(options)
         return
+    filtered = [option for option in stored if option in options]
+    for option in options:
+        if option not in filtered:
+            filtered.append(option)
+    st.session_state[key] = filtered
+
+
+def _configure_filters(hits: list[ProviderHit]) -> tuple[list[str], list[str], list[str]]:
+    provider_options = sorted({hit.provider for hit in hits})
+    telescope_options = sorted({hit.telescope for hit in hits if hit.telescope})
+    instrument_options = sorted({hit.instrument for hit in hits if hit.instrument})
+    _sync_options(_FILTER_PROVIDERS_KEY, provider_options)
+    _sync_options(_FILTER_TELESCOPES_KEY, telescope_options)
+    _sync_options(_FILTER_INSTRUMENTS_KEY, instrument_options)
+    return provider_options, telescope_options, instrument_options
+
+
+def _select_wave_window(hits: list[ProviderHit]) -> list[ProviderHit]:
+    wave_ranges = [hit.wave_range_nm for hit in hits if hit.wave_range_nm]
+    if not wave_ranges:
+        st.session_state.pop(_FILTER_WAVE_KEY, None)
+        return hits
+
+    min_wave = min(start for start, _ in wave_ranges)
+    max_wave = max(end for _, end in wave_ranges)
+    if _FILTER_WAVE_KEY not in st.session_state:
+        st.session_state[_FILTER_WAVE_KEY] = (float(min_wave), float(max_wave))
+    start_sel, end_sel = st.slider(
+        "Wavelength range (nm)",
+        min_value=float(min_wave),
+        max_value=float(max_wave),
+        value=st.session_state[_FILTER_WAVE_KEY],
+        key=_FILTER_WAVE_KEY,
+    )
+
+    def _within_wave(hit: ProviderHit) -> bool:
+        if not hit.wave_range_nm:
+            return True
+        start, end = hit.wave_range_nm
+        return end >= start_sel and start <= end_sel
+
+    return [hit for hit in hits if _within_wave(hit)]
+
+
+def _filtered_hits(state: _StarHubState) -> list[ProviderHit]:
+    hits = [state.hits[key] for key in state.hit_order if key in state.hits]
+    if not hits:
+        return []
+
+    provider_options, telescope_options, instrument_options = _configure_filters(hits)
+
+    selected_providers = st.multiselect(
+        "Providers",
+        provider_options,
+        default=st.session_state[_FILTER_PROVIDERS_KEY],
+        key=_FILTER_PROVIDERS_KEY,
+        help="Filter results by provider.",
+    )
+    selected_telescopes = st.multiselect(
+        "Telescopes",
+        telescope_options,
+        default=st.session_state[_FILTER_TELESCOPES_KEY],
+        key=_FILTER_TELESCOPES_KEY,
+        help="Filter results by telescope when available.",
+    )
+    selected_instruments = st.multiselect(
+        "Instruments",
+        instrument_options,
+        default=st.session_state[_FILTER_INSTRUMENTS_KEY],
+        key=_FILTER_INSTRUMENTS_KEY,
+        help="Filter results by instrument when available.",
+    )
+
+    candidates = _select_wave_window(hits)
+    filtered: list[ProviderHit] = []
+    for hit in candidates:
+        if selected_providers and hit.provider not in selected_providers:
+            continue
+        if selected_telescopes and hit.telescope not in selected_telescopes:
+            continue
+        if selected_instruments and hit.instrument not in selected_instruments:
+            continue
+        filtered.append(hit)
+    return filtered
+
+
+def _run_search(state: _StarHubState, identifier: str) -> None:
+    if state.resolver is None:
+        st.warning("Resolve a target before searching providers.")
+        return
+
+    provider_choices = provider_names()
+    default_selection = list(provider_choices)
+    selected_providers = st.multiselect(
+        "Providers to query",
+        provider_choices,
+        default=default_selection,
+        key="star_hub_providers_to_query",
+        help="Choose which providers to query.",
+    )
 
     radius = st.slider(
         "Search radius (arcsec)",
         min_value=1.0,
-        max_value=30.0,
-        value=5.0,
+        max_value=120.0,
+        value=10.0,
         step=1.0,
-        key="star_hub_mast_radius",
-    )
-
-    if st.button("Search MAST", key="star_hub_mast_search"):
-        with st.spinner("Querying MAST..."):
-            try:
-                products = list(
-                    mast.search_products(ra=resolver.ra, dec=resolver.dec, radius_arcsec=radius)
-                )
-            except RuntimeError as exc:
-                st.error(str(exc))
-            else:
-                state.mast_products = list(products)
-                if not products:
-                    st.info("No spectroscopic products found for the selected radius.")
-
-    if state.mast_products:
-        st.write(f"Found {len(state.mast_products)} spectroscopic product(s).")
-        for index, product in enumerate(state.mast_products):
-            _render_product_card(session, product, key_prefix=f"mast_{index}")
-
-
-def _sdss_specobj_controls(state: _StarHubState) -> None:
-    specobj_input = st.text_input("SpecObjID", key="star_hub_sdss_specobj")
-    if not st.button("Fetch by SpecObjID", key="star_hub_sdss_fetch_specobj"):
-        return
-    cleaned = specobj_input.strip()
-    if not cleaned:
-        st.error("Enter a SpecObjID to query SDSS.")
-        return
-    try:
-        specobjid = int(cleaned)
-    except ValueError:
-        st.error("SpecObjID must be an integer")
-        return
-    with st.spinner("Fetching SDSS spectrum..."):
-        try:
-            product = sdss.fetch_by_specobjid(specobjid)
-        except Exception as exc:  # pragma: no cover - network path
-            st.error(str(exc))
-            return
-    _store_sdss_product(state, product)
-
-
-def _sdss_plate_controls(state: _StarHubState) -> None:
-    plate_col, mjd_col, fiber_col = st.columns(3)
-    plate_input = plate_col.text_input("Plate", key="star_hub_sdss_plate")
-    mjd_input = mjd_col.text_input("MJD", key="star_hub_sdss_mjd")
-    fiber_input = fiber_col.text_input("Fiber", key="star_hub_sdss_fiber")
-    if not st.button("Fetch by plate/MJD/fiber", key="star_hub_sdss_fetch_plate"):
-        return
-    try:
-        plate = int(plate_input.strip())
-        mjd = int(mjd_input.strip())
-        fiber = int(fiber_input.strip())
-    except ValueError:
-        st.error("Plate, MJD, and Fiber must be integers")
-        return
-    with st.spinner("Fetching SDSS spectrum..."):
-        try:
-            product = sdss.fetch_by_plate(plate=plate, mjd=mjd, fiber=fiber)
-        except Exception as exc:  # pragma: no cover - network path
-            st.error(str(exc))
-            return
-    _store_sdss_product(state, product)
-
-
-def _render_sdss_search_section(session: AppSessionState, state: _StarHubState) -> None:
-    st.markdown("#### Search SDSS by resolved position")
-    resolver = state.resolver
-    if resolver is None or resolver.ra is None or resolver.dec is None:
-        st.info("Resolve a target with coordinates to search nearby SDSS spectra.")
-        return
-
-    radius = st.slider(
-        "Search radius (arcsec)",
-        min_value=1.0,
-        max_value=180.0,
-        value=30.0,
-        step=1.0,
-        key="star_hub_sdss_radius",
-    )
-    class_options = ["(any)", "STAR", "GALAXY", "QSO"]
-    selected_class = st.selectbox(
-        "Spectral class",
-        options=class_options,
-        index=0,
-        key="star_hub_sdss_class",
-        help="Filter SDSS results by the archive classification when available.",
+        key="star_hub_radius",
     )
     limit = st.slider(
         "Result limit",
@@ -215,75 +279,103 @@ def _render_sdss_search_section(session: AppSessionState, state: _StarHubState) 
         max_value=20,
         value=5,
         step=1,
-        key="star_hub_sdss_limit",
+        key="star_hub_limit",
     )
+    sdss_class = st.selectbox(
+        "SDSS spectral class",
+        options=["(any)", "STAR", "GALAXY", "QSO"],
+        index=0,
+        key="star_hub_sdss_class",
+        help="Limit SDSS results to a class when available.",
+    )
+    doi_filter = st.text_input(
+        "DOI filter",
+        value="",
+        key="star_hub_doi_filter",
+        help="Query DOI provider when a DOI is known.",
+    ).strip()
 
-    if st.button("Search SDSS region", key="star_hub_sdss_search"):
-        filter_kwargs: dict[str, Any] = {}
-        if selected_class != "(any)":
-            filter_kwargs["class_"] = selected_class
-        with st.spinner("Querying SDSS..."):
-            try:
-                products = list(
-                    sdss.search_spectra(
-                        ra=resolver.ra,
-                        dec=resolver.dec,
-                        radius_arcsec=radius,
-                        limit=limit,
-                        **filter_kwargs,
-                    )
-                )
-            except Exception as exc:  # pragma: no cover - network path
-                st.error(str(exc))
-            else:
-                state.sdss_search_results = products
-                if not products:
-                    st.info("No SDSS spectra found for the selected parameters.")
-
-    if state.sdss_search_results:
-        st.write(f"Found {len(state.sdss_search_results)} SDSS spectrum(s).")
-        for index, product in enumerate(state.sdss_search_results):
-            _render_product_card(session, product, key_prefix=f"sdss_search_{index}")
-
-
-def _render_sdss_section(session: AppSessionState, state: _StarHubState) -> None:
-    st.markdown("### SDSS archive")
-    _sdss_specobj_controls(state)
-    st.caption("Or fetch by plate / MJD / fiber identifiers")
-    _sdss_plate_controls(state)
-
-    _render_sdss_search_section(session, state)
-
-    if state.sdss_products:
-        st.write(f"Stored {len(state.sdss_products)} SDSS spectrum(s).")
-        for index, product in enumerate(state.sdss_products):
-            _render_product_card(session, product, key_prefix=f"sdss_{index}")
+    if st.button("Search providers", key="star_hub_search"):
+        filters: dict[str, Any] = {
+            "mast_radius_arcsec": radius,
+            "sdss_radius_arcsec": radius,
+            "sdss_limit": limit,
+        }
+        if sdss_class != "(any)":
+            filters["sdss_class"] = sdss_class
+        if doi_filter:
+            filters["doi"] = doi_filter
+        query = ProviderQuery(
+            identifier=identifier,
+            resolver=state.resolver,
+            radius_arcsec=radius,
+            limit=limit,
+            filters=filters,
+        )
+        with st.spinner("Searching providers..."):
+            hits = search_all(query, include=selected_providers or None)
+        _store_hits(state, hits)
+        if hits:
+            st.success(f"Found {len(hits)} product(s) across providers.")
+        else:
+            st.info("No matching products found for the current parameters.")
 
 
-def _store_sdss_product(state: _StarHubState, product: Product) -> None:
-    existing_ids = {item.product_id for item in state.sdss_products}
-    if product.product_id in existing_ids:
+def _ingest_selected(
+    session: AppSessionState, state: _StarHubState, selection: list[str] | None = None
+) -> None:
+    if selection is None:
+        raw_selection = state.selection
+    else:
+        raw_selection = selection
+    selected: list[str] = []
+    seen: set[str] = set()
+    for entry in raw_selection:
+        for key in _expand_selection_entry(entry, state.hits):
+            if key not in seen and key in state.hits:
+                seen.add(key)
+                selected.append(key)
+    if not selected:
+        st.warning("Select one or more products before adding to the overlay.")
         return
-    state.sdss_products.append(product)
+
+    hits = [state.hits[key] for key in selected]
+    with st.spinner("Downloading and ingesting selected products..."):
+        results: list[str] = []
+        for hit in hits:
+            try:
+                canonical = ingest_product(hit.product)
+            except ProductIngestError as exc:
+                st.error(str(exc))
+                continue
+            added, trace_id = session.register_trace(canonical)
+            label = canonical.label
+            if added:
+                results.append(f"✅ Added '{label}'")
+            else:
+                results.append(f"⚠️ Duplicate for '{label}' (trace {trace_id})")
+        if results:
+            st.write("\n".join(results))
+    st.session_state[_SELECTION_KEY] = []
 
 
-def render_star_hub_tab(session: AppSessionState) -> None:
+def render_star_hub_tab(session: "AppSessionState") -> None:  # noqa: UP037, C901
     st.subheader("Star Hub")
     state = _get_state()
 
     query = st.text_input("Resolve target (SIMBAD)", key="star_hub_query")
+    use_fixture = st.checkbox("Use fixture", key="star_hub_use_fixture")
     if st.button("Resolve", key="star_hub_resolve"):
         if not query.strip():
             st.error("Enter a target name or coordinates")
         else:
             with st.spinner("Resolving target..."):
                 try:
-                    result = resolver_simbad.resolve(query)
+                    result = resolver_simbad.resolve(query, use_fixture=use_fixture)
                 except Exception as exc:  # pragma: no cover - network path
                     st.error(f"Resolver error: {exc}")
                 else:
                     state.resolver = result
-                    state.mast_products.clear()
                     st.success(f"Resolved {result.canonical_name}")
 
     if state.resolver:
@@ -298,9 +390,32 @@ def render_star_hub_tab(session: AppSessionState) -> None:
                 "provenance": resolver.provenance,
             }
         )
-        _render_mast_section(session, state)
+        _run_search(state, query)
     else:
         st.info("Use the resolver above to seed archive searches.")
+        return
 
-    st.divider()
-    _render_sdss_section(session, state)
+    if state.hits:
+        st.divider()
+        st.markdown("### Provider results")
+        filtered = _filtered_hits(state)
+        option_keys = [_hit_key(hit) for hit in filtered]
+        options_map = {_hit_key(hit): hit for hit in filtered}
+        current_selection = [
+            key for key in st.session_state.get(_SELECTION_KEY, []) if key in options_map
+        ]
+
+        selection = st.multiselect(
+            "Select products to add to the overlay",
+            options=option_keys,
+            default=current_selection,
+            key=_SELECTION_KEY,
+            help="Choose product keys to ingest; details appear below.",
+        )
+        state.selection = list(selection)
+        for hit in filtered:
+            _render_hit_card(hit)
+        if st.button("Add selected to overlay", key="star_hub_add"):
+            _ingest_selected(session, state, selection)
+    else:
+        st.info("Run a provider search to view available products.")

--- a/atlas/fetchers_overview.md
+++ b/atlas/fetchers_overview.md
@@ -1,23 +1,29 @@
 # Fetchers Overview
 
-- Resolver: `server/fetchers/resolver_simbad.resolve` uses astroquery when available; falls back to
-  bundled `simbad_m31.json` fixture for offline tests.
-- Product model: `server/fetchers/models.py` defines `Product` and `ResolverResult` dataclasses.
+- Resolver: `server/fetchers/resolver_simbad.resolve` uses astroquery when available and supports an
+  explicit `use_fixture=True` toggle to fall back to the bundled `simbad_m31.json` payload for
+  offline tests.
+- Product model: `server/fetchers/models.py` defines `Product` and `ResolverResult` dataclasses used
+  across archive adapters.
+- Providers: `server/providers/__init__.py` implements the shared `ProviderQuery`/`ProviderHit`
+  models, a registry, and `search_all(...)` fan-out with duplicate suppression across provider hits.
 - MAST: `server/fetchers/mast.search_products` queries the archive via `astroquery.mast.Observations`
-  when available, filtering for spectroscopic products and augmenting metadata with direct download
-  URIs from the product list. The adapter normalises wavelength bounds to nanometres, extracts
-  pipeline provenance, and records auxiliary fields (collection, filters, exposure) in the `extra`
-  payload. Offline tests monkeypatch the client to avoid network access while exercising the
-  canonicalisation path.
-- SDSS: `server/fetchers/sdss.fetch_by_specobjid` / `fetch_by_plate` resolve metadata through
-  `astroquery.sdss.SDSS.query_specobj`, pull the calibrated spectrum via `get_spectra`, and derive
-  wavelength coverage/resolution from the FITS table. Products advertise vacuum wavelengths,
-  standard SDSS flux units (`1e-17 erg s^-1 cm^-2 Å^-1`), and include canonical download/portal
-  links. Offline coverage patches the SDSS client with synthetic tables/HDU lists.
+  when available, filtering for spectroscopic products and emitting `ProviderHit` records with
+  normalised wavelength bounds, provenance hints, and portal/download links. Offline tests
+  monkeypatch the client to avoid network access while exercising the canonicalisation path.
+- SDSS: `server/fetchers/sdss.search_spectra` runs region queries through `astroquery.sdss.SDSS`,
+  derives coverage/resolution from FITS tables, and emits `ProviderHit` metadata alongside the
+  direct spectrum download link. `fetch_by_specobjid`/`fetch_by_plate` remain available for targeted
+  lookups.
+- ESO: `server/fetchers/eso.search` provides curated VLT sample spectra for offline demos,
+  honouring instrument/telescope filters while populating preview/download metadata.
+- DOI: `server/fetchers/doi.search` resolves curated DOI mappings to archive products so DOI lookups
+  surface in the provider grid with deduplication against the originating archive.
 - Ingest: `server.fetchers.ingest_product.ingest_product` downloads archive payloads (FITS preferred,
-  ASCII fallback) and runs them through the canonical ingest pipeline. Metadata from the `Product`
-  model is merged into the resulting `TraceMetadata`, provenance logs the fetch step, and duplicates
-  are avoided via the existing session ledger.
-- Star Hub surfaces resolver output alongside MAST search results and SDSS fetch helpers so analysts
-  can add archive spectra directly to the overlay without leaving the app.
+  ASCII fallback) and runs them through the canonical ingest pipeline. Metadata from `Product`
+  models merges into `TraceMetadata`, provenance logs the fetch step, and duplicates are avoided via
+  the existing session ledger.
+- Star Hub fans out a resolved target to the provider registry, persists provider/telescope/
+  instrument/λ filters in `st.session_state`, renders previews where available, and supports
+  multi-select overlay ingestion.
 - Tests rely on local fixtures/stubs; network lookups remain optional for integration runs.

--- a/atlas/ui_contract.md
+++ b/atlas/ui_contract.md
@@ -8,5 +8,7 @@
   provenance caption, and similarity analysis controls (viewport, metrics, ribbon, matrices).
 - Differential tab: select boxes for trace A/B, buttons for subtraction and ratio with identical
   suppression messaging.
-- Star Hub: SIMBAD resolver card placeholder; future runs expand provider grid.
+- Star Hub: SIMBAD resolver with fixture toggle, provider fan-out controls (radius, limit, DOI),
+  persistent provider/telescope/instrument/λ filters, preview panels, and multi-select "Add to
+  overlay" button.
 - Docs tab: renders markdown from `docs/static`.

--- a/docs/static/overview.md
+++ b/docs/static/overview.md
@@ -8,8 +8,9 @@ and exporting manifests that replay the current view. The current build includes
   duplicate detection.
 - Export bundles (manifest v2, per-trace CSVs, optional PNG) with a replay stub that
   reconstructs visible traces.
-- Fe I line overlays with scaling controls plus an offline SIMBAD resolver fixture, now paired with
-  MAST and SDSS archive wiring so resolved targets can pull spectra straight into the overlay.
+- Fe I line overlays with scaling controls plus an offline SIMBAD resolver fixture. The Star Hub now
+  resolves once, fans out to MAST/SDSS/ESO/DOI providers via the registry, surfaces previews,
+  persists filters, and supports multi-select ingestion straight into the overlay.
 - Frequency- and energy-based uploads (Hz–PHz, eV/keV/MeV) auto-convert to the wavelength baseline
   during ingest, with provenance capturing the detected axis family.
 - Overlay trace manager surfaces the detected axis family, units, detection method, and downstream

--- a/server/fetchers/doi.py
+++ b/server/fetchers/doi.py
@@ -1,0 +1,88 @@
+"""DOI resolver adapter returning curated archive products."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Any, cast
+
+from server.fetchers.models import Product
+from server.providers import ProviderHit, ProviderQuery, register_provider
+
+_SAMPLE_DOIS: dict[str, dict[str, Any]] = {
+    "10.17909/t9xx11": {
+        "product_id": "123",
+        "title": "HST/STIS calibrated spectrum",
+        "target": "M31",
+        "provider": "MAST",
+        "ra": 10.6847083,
+        "dec": 41.269065,
+        "wave_range_nm": (100.0, 200.0),
+        "resolution_R": 1200.0,
+        "preview": "https://mast.stsci.edu/spectrum.jpg",
+        "download": "https://mast.stsci.edu/api/v0.1/Download/file?uri=mast:HLSP/test/spectrum.fits",
+        "portal": "https://doi.org/10.17909/T9XX11",
+        "pipeline_version": "CALSPEC v1",
+    }
+}
+
+
+def _build_product(record: dict[str, Any]) -> Product:
+    urls = {
+        "download": str(record["download"]),
+        "portal": str(record["portal"]),
+        "preview": str(record["preview"]),
+    }
+    wave_range = cast(tuple[float, float], record["wave_range_nm"])
+    product = Product(
+        provider=str(record["provider"]),
+        product_id=str(record["product_id"]),
+        title=str(record["title"]),
+        target=str(record["target"]),
+        ra=float(cast(float, record["ra"])),
+        dec=float(cast(float, record["dec"])),
+        wave_range_nm=(float(wave_range[0]), float(wave_range[1])),
+        resolution_R=float(cast(float, record["resolution_R"])),
+        wavelength_standard="unknown",
+        flux_units="erg s^-1 cm^-2 Å^-1",
+        pipeline_version=str(record["pipeline_version"]),
+        urls=urls,
+        citation="Digital Object Identifier",
+        doi="10.17909/T9XX11",
+        extra={"source": "doi"},
+    )
+    return product
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    doi_candidate: str | None = None
+    if query.filters:
+        filter_value = query.filters.get("doi")
+        if isinstance(filter_value, str):
+            doi_candidate = filter_value.strip()
+    if not doi_candidate and query.identifier.lower().startswith("10."):
+        doi_candidate = query.identifier.strip()
+    if not doi_candidate:
+        return []
+    record = _SAMPLE_DOIS.get(doi_candidate.lower())
+    if record is None:
+        return []
+    product = _build_product(record)
+    return [
+        ProviderHit(
+            provider="DOI",
+            product=replace(product),
+            telescope=None,
+            instrument=None,
+            wave_range_nm=product.wave_range_nm,
+            preview_url=product.urls.get("preview"),
+            download_url=product.urls.get("download") or product.urls.get("portal"),
+            extras={"doi": product.doi},
+        )
+    ]
+
+
+register_provider("DOI", search)
+
+
+__all__ = ["search"]

--- a/server/fetchers/eso.py
+++ b/server/fetchers/eso.py
@@ -1,0 +1,148 @@
+"""ESO archive adapter backed by curated sample metadata."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable
+from dataclasses import replace
+from typing import Any, cast
+
+from server.fetchers.models import Product
+from server.providers import ProviderHit, ProviderQuery, register_provider
+
+_SAMPLE_DATA = [
+    {
+        "product_id": "ESO-UVES-001",
+        "title": "VLT/UVES high-resolution spectrum",
+        "target": "M31",
+        "ra": 10.6847083,
+        "dec": 41.269065,
+        "wave_range_nm": (320.0, 1050.0),
+        "resolution_R": 40000.0,
+        "telescope": "VLT",
+        "instrument": "UVES",
+        "doi": "10.18727/ESO/SA-1234",
+        "preview": "https://example.com/eso/uves_preview.jpg",
+        "download": "https://archive.eso.org/datasets/eso-uves-001.fits",
+        "pipeline_version": "6.0.1",
+    },
+    {
+        "product_id": "ESO-XSH-002",
+        "title": "VLT/X-shooter medium-resolution spectrum",
+        "target": "M31",
+        "ra": 10.6847083,
+        "dec": 41.269065,
+        "wave_range_nm": (300.0, 2480.0),
+        "resolution_R": 7500.0,
+        "telescope": "VLT",
+        "instrument": "X-shooter",
+        "doi": "10.18727/ESO/SA-5678",
+        "preview": "https://example.com/eso/xshooter_preview.jpg",
+        "download": "https://archive.eso.org/datasets/eso-xshooter-002.fits",
+        "pipeline_version": "3.5.0",
+    },
+]
+
+
+def _build_product(entry: dict[str, Any]) -> Product:
+    urls = {
+        "download": str(entry["download"]),
+        "portal": "https://archive.eso.org/scienceportal/home",
+        "preview": str(entry["preview"]),
+    }
+    extra = {
+        "telescope": entry["telescope"],
+        "instrument": entry["instrument"],
+    }
+    wave_range = cast(tuple[float, float], entry["wave_range_nm"])
+    product = Product(
+        provider="ESO",
+        product_id=str(entry["product_id"]),
+        title=str(entry["title"]),
+        target=str(entry["target"]),
+        ra=float(cast(float, entry["ra"])),
+        dec=float(cast(float, entry["dec"])),
+        wave_range_nm=(float(wave_range[0]), float(wave_range[1])),
+        resolution_R=float(cast(float, entry["resolution_R"])),
+        wavelength_standard="vacuum",
+        flux_units="erg s^-1 cm^-2 Å^-1",
+        pipeline_version=str(entry["pipeline_version"]),
+        urls=urls,
+        citation="ESO Science Archive",
+        doi=str(entry["doi"]),
+        extra=extra,
+    )
+    return product
+
+
+def _hit_from_product(product: Product) -> ProviderHit:
+    return ProviderHit(
+        provider="ESO",
+        product=replace(product),
+        telescope=str(product.extra.get("telescope")) if product.extra.get("telescope") else None,
+        instrument=(
+            str(product.extra.get("instrument")) if product.extra.get("instrument") else None
+        ),
+        wave_range_nm=product.wave_range_nm,
+        preview_url=product.urls.get("preview"),
+        download_url=product.urls.get("download"),
+        extras={"doi": product.doi},
+    )
+
+
+def _within_radius(
+    entry: dict[str, object], coordinates: tuple[float, float], radius_arcsec: float
+) -> bool:
+    ra, dec = coordinates
+    dra = float(cast(float, entry["ra"])) - ra
+    dec_entry = float(cast(float, entry["dec"]))
+    dec_avg = math.radians((dec_entry + dec) / 2.0)
+    separation_deg = math.hypot(dra * math.cos(dec_avg), dec_entry - dec)
+    return separation_deg <= radius_arcsec / 3600.0
+
+
+def _normalise_filter(value: object | None) -> set[str] | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        return {cleaned.lower()} if cleaned else None
+    if isinstance(value, Iterable):
+        normalised = {str(item).strip().lower() for item in value if str(item).strip()}
+        return normalised or None
+    return {str(value).strip().lower()}
+
+
+def search(query: ProviderQuery) -> Iterable[ProviderHit]:
+    coordinates = query.coordinates()
+    if coordinates is None:
+        return []
+
+    radius = query.radius_arcsec if query.radius_arcsec is not None else 20.0
+    try:
+        radius_value = float(radius)
+    except (TypeError, ValueError):
+        radius_value = 20.0
+
+    instrument_filter = (
+        _normalise_filter(query.filters.get("eso_instrument")) if query.filters else None
+    )
+    telescope_filter = (
+        _normalise_filter(query.filters.get("eso_telescope")) if query.filters else None
+    )
+    hits: list[ProviderHit] = []
+    for entry in _SAMPLE_DATA:
+        if not _within_radius(entry, coordinates, radius_value):
+            continue
+        if instrument_filter and str(entry["instrument"]).lower() not in instrument_filter:
+            continue
+        if telescope_filter and str(entry["telescope"]).lower() not in telescope_filter:
+            continue
+        hits.append(_hit_from_product(_build_product(entry)))
+    return hits
+
+
+register_provider("ESO", search)
+
+
+__all__ = ["search"]

--- a/server/fetchers/resolver_simbad.py
+++ b/server/fetchers/resolver_simbad.py
@@ -78,8 +78,8 @@ def _load_fixture(identifier: str) -> ResolverResult | None:
     )
 
 
-def resolve(identifier: str) -> ResolverResult:
-    """Resolve an identifier using SIMBAD or bundled fixtures."""
+def resolve(identifier: str, *, use_fixture: bool = False) -> ResolverResult:
+    """Resolve an identifier using SIMBAD with an optional fixture fallback."""
 
     identifier = identifier.strip()
     if not identifier:
@@ -89,11 +89,13 @@ def resolve(identifier: str) -> ResolverResult:
     if online is not None:
         return online
 
-    fixture = _load_fixture(identifier)
-    if fixture is not None:
-        return fixture
+    if use_fixture:
+        fixture = _load_fixture(identifier)
+        if fixture is not None:
+            return fixture
 
-    raise LookupError(f"Unable to resolve '{identifier}' via SIMBAD or fixtures")
+    suffix = " or fixture" if use_fixture else ""
+    raise LookupError(f"Unable to resolve '{identifier}' via SIMBAD{suffix}")
 
 
 __all__ = ["resolve"]

--- a/server/ingest/nist_lines.py
+++ b/server/ingest/nist_lines.py
@@ -26,7 +26,9 @@ def _prepare_rows(rows: Iterable[dict[str, Any]]) -> list[dict[str, Any]]:
             numeric_intensity = float(intensity)
         except Exception:
             continue
-        prepared.append({**row, "wavelength_nm": numeric_wavelength, "relative_intensity": numeric_intensity})
+        prepared.append(
+            {**row, "wavelength_nm": numeric_wavelength, "relative_intensity": numeric_intensity}
+        )
     prepared.sort(key=lambda item: item["wavelength_nm"])
     return prepared
 
@@ -48,13 +50,17 @@ def _label(species: str, window: tuple[float, float] | None) -> str:
     return f"NIST lines: {species} {low:.1f}–{high:.1f} nm"
 
 
-def _compute_hash(rows: list[dict[str, Any]], species: str, window: tuple[float, float] | None) -> str:
+def _compute_hash(
+    rows: list[dict[str, Any]], species: str, window: tuple[float, float] | None
+) -> str:
     payload = {
         "species": species,
         "window": window,
         "rows": rows,
     }
-    digest = hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(
+        json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()
     return digest
 
 

--- a/server/providers/__init__.py
+++ b/server/providers/__init__.py
@@ -1,0 +1,130 @@
+"""Provider registry and search fan-out helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from typing import Any
+
+from server.fetchers.models import Product, ResolverResult
+
+
+@dataclass(slots=True)
+class ProviderQuery:
+    """Parameters passed to provider search adapters."""
+
+    identifier: str
+    resolver: ResolverResult | None = None
+    radius_arcsec: float | None = None
+    limit: int | None = None
+    filters: dict[str, Any] = field(default_factory=dict)
+
+    def coordinates(self) -> tuple[float, float] | None:
+        """Return the resolved coordinates when available."""
+
+        if self.resolver is None:
+            return None
+        if self.resolver.ra is None or self.resolver.dec is None:
+            return None
+        return (self.resolver.ra, self.resolver.dec)
+
+
+@dataclass(slots=True)
+class ProviderHit:
+    """A single search result from a provider."""
+
+    provider: str
+    product: Product
+    telescope: str | None = None
+    instrument: str | None = None
+    wave_range_nm: tuple[float, float] | None = None
+    preview_url: str | None = None
+    download_url: str | None = None
+    extras: dict[str, Any] = field(default_factory=dict)
+
+
+ProviderSearch = Callable[[ProviderQuery], Iterable[ProviderHit]]
+
+_LOGGER = logging.getLogger(__name__)
+_REGISTRY: dict[str, ProviderSearch] = {}
+_DEFAULTS_LOADED = False
+
+
+def register_provider(name: str, search: ProviderSearch, /) -> None:
+    """Register a provider search function."""
+
+    _REGISTRY[name] = search
+
+
+def unregister_provider(name: str) -> None:
+    """Remove a provider from the registry (primarily for tests)."""
+
+    _REGISTRY.pop(name, None)
+
+
+def _ensure_defaults_loaded() -> None:
+    global _DEFAULTS_LOADED
+    if _DEFAULTS_LOADED:
+        return
+    # Import adapters lazily to avoid circular imports and optional dependencies.
+    from server.fetchers import doi, eso, mast, sdss  # noqa: F401
+
+    _DEFAULTS_LOADED = True
+
+
+def provider_names() -> tuple[str, ...]:
+    """Return the names of registered providers."""
+
+    _ensure_defaults_loaded()
+    return tuple(_REGISTRY.keys())
+
+
+def search_all(query: ProviderQuery, *, include: Iterable[str] | None = None) -> list[ProviderHit]:
+    """Fan out the query to all registered providers with deduplication."""
+
+    _ensure_defaults_loaded()
+
+    selected = set(include) if include is not None else None
+    hits: list[ProviderHit] = []
+    seen: set[tuple[str, str]] = set()
+
+    for name, search in _REGISTRY.items():
+        if selected is not None and name not in selected:
+            continue
+        try:
+            results = list(search(query))
+        except Exception as exc:
+            _LOGGER.warning("Provider %s search failed: %s", name, exc)
+            continue
+        for hit in results:
+            product = hit.product
+            product_id = product.product_id or product.title or ""
+            key = (product.provider or hit.provider or name, product_id)
+            if not product_id:
+                key = (product.provider or hit.provider or name, str(id(product)))
+            if key in seen:
+                continue
+            seen.add(key)
+            if hit.wave_range_nm is None:
+                hit.wave_range_nm = product.wave_range_nm
+            if hit.download_url is None:
+                hit.download_url = (
+                    product.urls.get("download")
+                    or product.urls.get("product")
+                    or product.urls.get("portal")
+                )
+            if hit.preview_url is None:
+                hit.preview_url = product.urls.get("preview")
+            hits.append(hit)
+    return hits
+
+
+__all__ = [
+    "ProviderHit",
+    "ProviderQuery",
+    "provider_names",
+    "register_provider",
+    "search_all",
+    "unregister_provider",
+]

--- a/tests/test_fetchers_mast.py
+++ b/tests/test_fetchers_mast.py
@@ -60,10 +60,13 @@ class _FakeObservations:
 def test_mast_search_products(monkeypatch) -> None:
     monkeypatch.setattr(mast, "Observations", _FakeObservations)
 
-    products = list(mast.search_products(ra=10.0, dec=20.0, radius_arcsec=5.0))
+    hits = list(mast.search_products(ra=10.0, dec=20.0, radius_arcsec=5.0))
 
-    assert len(products) == 1
-    product = products[0]
+    assert len(hits) == 1
+    hit = hits[0]
+    product = hit.product
+    assert hit.provider == "MAST"
+    assert hit.preview_url == "https://mast.stsci.edu/spectrum.jpg"
     assert product.provider == "MAST"
     assert product.product_id == "123"
     assert product.title == "Test spectrum"

--- a/tests/test_fetchers_sdss.py
+++ b/tests/test_fetchers_sdss.py
@@ -105,7 +105,7 @@ def test_sdss_search_spectra_class_filter(monkeypatch) -> None:
     monkeypatch.setattr(sdss, "SDSS", _FakeSDSS)
     _FakeSDSS.reset()
 
-    products = list(
+    hits = list(
         sdss.search_spectra(
             ra=150.0,
             dec=2.3,
@@ -115,7 +115,10 @@ def test_sdss_search_spectra_class_filter(monkeypatch) -> None:
         )
     )
 
-    assert products
+    assert hits
+    hit = hits[0]
+    assert hit.provider == "SDSS"
+    assert hit.download_url.endswith("specobjid=1234567890")
     assert _FakeSDSS.last_query_sql is not None
     assert "TOP 5" in _FakeSDSS.last_query_sql
     assert "class IN ('STAR')" in _FakeSDSS.last_query_sql

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from server.fetchers import doi
+from server.fetchers.eso import search as eso_search
+from server.fetchers.models import Product, ResolverResult
+from server.providers import (
+    ProviderHit,
+    ProviderQuery,
+    register_provider,
+    search_all,
+    unregister_provider,
+)
+
+
+def _resolver() -> ResolverResult:
+    return ResolverResult(
+        canonical_name="M31",
+        ra=10.6847083,
+        dec=41.269065,
+        object_type="GALAXY",
+        aliases=["Andromeda"],
+        provenance={"source": "test"},
+    )
+
+
+def test_eso_provider_filters() -> None:
+    query = ProviderQuery(identifier="M31", resolver=_resolver(), radius_arcsec=30.0)
+    hits = list(eso_search(query))
+    assert len(hits) == 2
+
+    filtered_query = ProviderQuery(
+        identifier="M31",
+        resolver=_resolver(),
+        radius_arcsec=30.0,
+        filters={"eso_instrument": "UVES"},
+    )
+    filtered_hits = list(eso_search(filtered_query))
+    assert len(filtered_hits) == 1
+    assert filtered_hits[0].instrument == "UVES"
+
+
+def test_doi_provider_matches_filter() -> None:
+    query = ProviderQuery(identifier="M31", resolver=_resolver(), filters={})
+    assert list(doi.search(query)) == []
+
+    doi_query = ProviderQuery(
+        identifier="10.17909/T9XX11",
+        resolver=_resolver(),
+        filters={"doi": "10.17909/T9XX11"},
+    )
+    hits = list(doi.search(doi_query))
+    assert len(hits) == 1
+    hit = hits[0]
+    assert hit.provider == "DOI"
+    assert hit.product.provider == "MAST"
+
+
+def test_registry_deduplicates_hits() -> None:
+    product = Product(
+        provider="TEST-ARCHIVE",
+        product_id="shared",
+        title="Shared spectrum",
+        target="Target",
+        ra=1.0,
+        dec=1.0,
+        wave_range_nm=(400.0, 500.0),
+        resolution_R=1000.0,
+        wavelength_standard="vacuum",
+        flux_units="unit",
+        pipeline_version="v1",
+        urls={"download": "https://example.com/shared.fits"},
+        citation="Test",
+        doi=None,
+        extra={},
+    )
+
+    def provider_one(_: ProviderQuery):
+        return [ProviderHit(provider="ONE", product=product)]
+
+    def provider_two(_: ProviderQuery):
+        return [ProviderHit(provider="TWO", product=product)]
+
+    register_provider("TEST_ONE", provider_one)
+    register_provider("TEST_TWO", provider_two)
+
+    try:
+        query = ProviderQuery(identifier="target", resolver=_resolver())
+        hits = search_all(query, include=["TEST_ONE", "TEST_TWO"])
+        assert len(hits) == 1
+        assert hits[0].product.product_id == "shared"
+    finally:
+        unregister_provider("TEST_ONE")
+        unregister_provider("TEST_TWO")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,7 +4,7 @@ from server.fetchers import resolver_simbad
 
 
 def test_resolver_fixture_m31() -> None:
-    result = resolver_simbad.resolve("M 31")
+    result = resolver_simbad.resolve("M 31", use_fixture=True)
     assert result.canonical_name == "M 31"
     assert result.ra is not None and result.dec is not None
     assert "Messier 31" in result.aliases

--- a/tests/test_ui_nist_sidebar.py
+++ b/tests/test_ui_nist_sidebar.py
@@ -4,6 +4,8 @@ from streamlit.testing.v1 import AppTest
 
 from app.state.session import AppSessionState
 from app.ui import main as main_ui
+
+
 class _FakeCatalog:
     def species(self) -> list[str]:
         return ["Fe I", "Mg II"]
@@ -52,9 +54,7 @@ def test_sidebar_form_registers_nist_trace(monkeypatch) -> None:
 
     settings = {"line_overlays": {"default_species": "Fe I", "default_window_nm": [500.0, 501.0]}}
 
-    at = AppTest.from_function(
-        _render_sidebar_app, args=(session, catalog, settings)
-    ).run()
+    at = AppTest.from_function(_render_sidebar_app, args=(session, catalog, settings)).run()
     at.sidebar.button(key="nist_fetch_submit").click().run()
 
     assert session.trace_order

--- a/tests/test_ui_star_hub.py
+++ b/tests/test_ui_star_hub.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import numpy as np
+from streamlit.testing.v1 import AppTest
+
+from app.state.session import AppSessionState
+from server.fetchers.models import Product, ResolverResult
+from server.models import CanonicalSpectrum, TraceMetadata
+from server.providers import ProviderHit, ProviderQuery
+
+
+def _render_star_hub(session) -> None:
+    from app.ui.star_hub import render_star_hub_tab as _render
+
+    _render(session)
+
+
+def _resolver() -> ResolverResult:
+    return ResolverResult(
+        canonical_name="M31",
+        ra=10.6847083,
+        dec=41.269065,
+        object_type="GALAXY",
+        aliases=["Andromeda"],
+        provenance={"source": "test"},
+    )
+
+
+def _product(provider: str, product_id: str, title: str) -> Product:
+    return Product(
+        provider=provider,
+        product_id=product_id,
+        title=title,
+        target="M31",
+        ra=10.6847083,
+        dec=41.269065,
+        wave_range_nm=(100.0, 200.0),
+        resolution_R=1000.0,
+        wavelength_standard="vacuum",
+        flux_units="erg",
+        pipeline_version="v1",
+        urls={"download": f"https://example.com/{product_id}.fits"},
+        citation="Test",
+        doi=None,
+        extra={},
+    )
+
+
+def test_star_hub_flow(monkeypatch) -> None:
+    session = AppSessionState()
+    resolver = _resolver()
+
+    hits = [
+        ProviderHit(
+            provider="MAST",
+            product=_product("MAST", "mast-1", "MAST spectrum"),
+            telescope="HST",
+            instrument="STIS",
+            wave_range_nm=(100.0, 200.0),
+            preview_url="https://example.com/mast_preview.jpg",
+            download_url="https://example.com/mast-1.fits",
+        ),
+        ProviderHit(
+            provider="SDSS",
+            product=_product("SDSS", "sdss-2", "SDSS spectrum"),
+            telescope="SDSS",
+            instrument="BOSS",
+            wave_range_nm=(360.0, 950.0),
+            preview_url="https://example.com/sdss_preview.jpg",
+            download_url="https://example.com/sdss-2.fits",
+        ),
+    ]
+
+    captured_queries: list[tuple] = []
+    ingested_products: list[str] = []
+
+    def fake_resolve(identifier: str, *, use_fixture: bool) -> ResolverResult:  # noqa: FBT002
+        assert use_fixture is True
+        assert identifier == "M31"
+        return resolver
+
+    def fake_provider_names() -> tuple[str, ...]:
+        return ("MAST", "SDSS")
+
+    def fake_search_all(query, *, include=None):
+        captured_queries.append((query, include))
+        return hits
+
+    def fake_ingest(product: Product) -> CanonicalSpectrum:
+        ingested_products.append(product.product_id)
+        metadata = TraceMetadata(
+            provider=product.provider, product_id=product.product_id, title=product.title
+        )
+        return CanonicalSpectrum(
+            label=product.title,
+            wavelength_vac_nm=np.array([100.0]),
+            values=np.array([1.0]),
+            value_mode="flux_density",
+            value_unit=product.flux_units,
+            metadata=metadata,
+            provenance=[],
+            source_hash=product.product_id,
+        )
+
+    monkeypatch.setattr("app.ui.star_hub.resolver_simbad.resolve", fake_resolve)
+    monkeypatch.setattr("app.ui.star_hub.provider_names", fake_provider_names)
+    monkeypatch.setattr("app.ui.star_hub.search_all", fake_search_all)
+    monkeypatch.setattr("app.ui.star_hub.ingest_product", fake_ingest)
+
+    at = AppTest.from_function(_render_star_hub, args=(session,)).run()
+
+    at.text_input(key="star_hub_query").input("M31").run()
+    at.checkbox(key="star_hub_use_fixture").check().run()
+    at.button(key="star_hub_resolve").click().run()
+
+    # Trigger provider search.
+    at.button(key="star_hub_search").click().run()
+
+    # Select both products and ingest them.
+    selection_key = "MAST:mast-1"
+    selection_key_two = "SDSS:sdss-2"
+    at.multiselect(key="star_hub_selection").select([selection_key, selection_key_two]).run()
+    at.button(key="star_hub_add").click().run()
+
+    assert ingested_products == ["mast-1", "sdss-2"]
+    assert captured_queries
+    query, include = captured_queries[-1]
+    assert isinstance(query, ProviderQuery)
+    assert include == ["MAST", "SDSS"]


### PR DESCRIPTION
## Summary
- track Star Hub multiselect choices inside component state and normalize arbitrary widget payloads
- expand selection parsing helpers to interpret stringified lists and maintain deduplicated keys prior to ingestion
- rely on native widget interactions in the UI test without mutating session state directly

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5f3ee398883299d242411413fa63a